### PR TITLE
[BUGFIX] Fix target branch in Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
+    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10
@@ -18,6 +19,7 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
+    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10


### PR DESCRIPTION
The target branch is `develop`, since we're using Git Flow.