### PR TITLE
[BUGFIX] Use static return for `TransformerInterface::fromArray`

### DIFF
--- a/src/Asset/Environment/Transformer/PassthroughTransformer.php
+++ b/src/Asset/Environment/Transformer/PassthroughTransformer.php
@@ -34,7 +34,7 @@ final class PassthroughTransformer implements TransformerInterface
     /**
      * @param array{} $config
      */
-    public static function fromArray(array $config): TransformerInterface
+    public static function fromArray(array $config): static
     {
         return new self();
     }

--- a/src/Asset/Environment/Transformer/SlugTransformer.php
+++ b/src/Asset/Environment/Transformer/SlugTransformer.php
@@ -45,7 +45,7 @@ final class SlugTransformer implements TransformerInterface
     /**
      * @param array{pattern?: string} $config
      */
-    public static function fromArray(array $config): TransformerInterface
+    public static function fromArray(array $config): static
     {
         if (!isset($config['pattern'])) {
             return new self();

--- a/src/Asset/Environment/Transformer/StaticTransformer.php
+++ b/src/Asset/Environment/Transformer/StaticTransformer.php
@@ -43,7 +43,7 @@ final class StaticTransformer implements TransformerInterface
     /**
      * @param array{value?: string} $config
      */
-    public static function fromArray(array $config): TransformerInterface
+    public static function fromArray(array $config): static
     {
         if (!is_string($value = $config['value'] ?? null)) {
             throw MissingConfigurationException::forKey('value');

--- a/src/Asset/Environment/Transformer/TransformerInterface.php
+++ b/src/Asset/Environment/Transformer/TransformerInterface.php
@@ -33,10 +33,8 @@ interface TransformerInterface
 {
     /**
      * @param array<string, mixed> $config
-     *
-     * @return static
      */
-    public static function fromArray(array $config): self;
+    public static function fromArray(array $config): static;
 
     /**
      * @return array<string, mixed>

--- a/src/Asset/Environment/Transformer/VersionTransformer.php
+++ b/src/Asset/Environment/Transformer/VersionTransformer.php
@@ -43,7 +43,7 @@ final class VersionTransformer implements TransformerInterface
     /**
      * @param array{version?: string} $config
      */
-    public static function fromArray(array $config): TransformerInterface
+    public static function fromArray(array $config): static
     {
         if (!is_string($version = $config['version'] ?? null)) {
             throw MissingConfigurationException::forKey('version');


### PR DESCRIPTION
Since PHP 8.0, the `static` return type annotation can be used. It is now added to the `TransformerInterface::fromArray()` method to properly reflect the existing annotation.