### PR TITLE
[!!!][FEATURE] Expect config object in `SchemaValidator::validate()`

### DIFF
--- a/src/Command/ConfigAssetsCommand.php
+++ b/src/Command/ConfigAssetsCommand.php
@@ -265,7 +265,7 @@ final class ConfigAssetsCommand extends BaseAssetsCommand
         $config['frontend-assets'] = array_values($config['frontend-assets']);
 
         // Validate new config
-        if (!$this->validator->validate($config->asArray())) {
+        if (!$this->validator->validate($config)) {
             throw Exception\InvalidConfigurationException::asReported($this->validator->getLastValidationErrors()->errors());
         }
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -25,6 +25,7 @@ namespace CPSIT\FrontendAssetHandler\Config;
 
 use ArrayIterator;
 use ArrayObject;
+use JsonSerializable;
 
 /**
  * Config.
@@ -32,9 +33,9 @@ use ArrayObject;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  *
- * @extends  \ArrayObject<string, mixed>
+ * @extends \ArrayObject<string, mixed>
  */
-final class Config extends ArrayObject
+final class Config extends ArrayObject implements JsonSerializable
 {
     /**
      * @param array<string, mixed> $config
@@ -57,5 +58,13 @@ final class Config extends ArrayObject
     public function asArray(): array
     {
         return (array) $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->asArray();
     }
 }

--- a/src/Config/Parser/Parser.php
+++ b/src/Config/Parser/Parser.php
@@ -55,7 +55,7 @@ class Parser
         $requiredKeys = $instructions->getRequiredKeys();
 
         // Validate config
-        if (!$this->validator->validate($config->asArray())) {
+        if (!$this->validator->validate($config)) {
             throw Exception\InvalidConfigurationException::asReported($this->validator->getLastValidationErrors()->errors());
         }
 

--- a/src/Json/SchemaValidator.php
+++ b/src/Json/SchemaValidator.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Json;
 
+use CPSIT\FrontendAssetHandler\Config;
 use CPSIT\FrontendAssetHandler\Exception;
 use Ergebnis\Json\SchemaValidator as ErgebnisSchemaValidator;
 use JsonException;
@@ -52,13 +53,11 @@ final class SchemaValidator
     }
 
     /**
-     * @param array<string, mixed> $jsonArray
-     *
      * @throws JsonException
      */
-    public function validate(array $jsonArray): bool
+    public function validate(Config\Config $config): bool
     {
-        $json = ErgebnisSchemaValidator\Json::fromString(json_encode($jsonArray, JSON_THROW_ON_ERROR));
+        $json = ErgebnisSchemaValidator\Json::fromString(json_encode($config, JSON_THROW_ON_ERROR));
         $schema = ErgebnisSchemaValidator\Json::fromFile($this->schemaFile);
         $jsonPointer = ErgebnisSchemaValidator\JsonPointer::empty();
 

--- a/tests/Unit/Json/SchemaValidatorTest.php
+++ b/tests/Unit/Json/SchemaValidatorTest.php
@@ -23,8 +23,9 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Tests\Unit\Json;
 
-use CPSIT\FrontendAssetHandler\Json\SchemaValidator;
-use CPSIT\FrontendAssetHandler\Tests\Unit\ContainerAwareTestCase;
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Json;
+use CPSIT\FrontendAssetHandler\Tests;
 
 /**
  * SchemaValidatorTest.
@@ -32,35 +33,33 @@ use CPSIT\FrontendAssetHandler\Tests\Unit\ContainerAwareTestCase;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-class SchemaValidatorTest extends ContainerAwareTestCase
+class SchemaValidatorTest extends Tests\Unit\ContainerAwareTestCase
 {
-    private SchemaValidator $subject;
+    private Json\SchemaValidator $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->subject = $this->container->get(SchemaValidator::class);
+        $this->subject = $this->container->get(Json\SchemaValidator::class);
     }
 
     /**
      * @test
      */
-    public function validateReturnsFalseOnInvalidJsonArray(): void
+    public function validateReturnsFalseOnInvalidConfig(): void
     {
-        $jsonArray = [
-            'foo' => 'baz',
-        ];
+        $config = new Config\Config(['foo' => 'baz'], 'foo');
 
-        self::assertFalse($this->subject->validate($jsonArray));
+        self::assertFalse($this->subject->validate($config));
     }
 
     /**
      * @test
      */
-    public function validateReturnsTrueOnValidJsonArray(): void
+    public function validateReturnsTrueOnValidConfig(): void
     {
-        $jsonArray = [
+        $config = new Config\Config([
             'frontend-assets' => [
                 [
                     'source' => [
@@ -73,8 +72,8 @@ class SchemaValidatorTest extends ContainerAwareTestCase
                     ],
                 ],
             ],
-        ];
+        ], 'foo');
 
-        self::assertTrue($this->subject->validate($jsonArray));
+        self::assertTrue($this->subject->validate($config));
     }
 }


### PR DESCRIPTION
With this PR, the `SchemaValidator::validate()` method now expects a valid `Config` object instead of a resolved array. Additionally, the `Config` object now implements `JsonSerializable` and can therefore passed to the `json_encode` method as-is.