### PR TITLE
[!!!][FEATURE] Do not process values by default in `config` command

### DIFF
--- a/docs/usage/cli-config-assets.md
+++ b/docs/usage/cli-config-assets.md
@@ -48,6 +48,17 @@ Treat the value passed with `newValue` argument as JSON.
 * Shorthand: **–**
 * Default: **no**
 
+## `--process-values`
+
+Run [value processors](../components/placeholder-processors.md) when reading or
+validating asset configuration.
+
+> :warning: This option has no effect with the `newValue` argument.
+
+* Required: **no**
+* Shorthand: **–**
+* Default: **no**
+
 ## `path`
 
 The path to the configuration value to be read or written inside the configuration

--- a/src/Command/BaseAssetsCommand.php
+++ b/src/Command/BaseAssetsCommand.php
@@ -55,7 +55,7 @@ abstract class BaseAssetsCommand extends Console\Command\Command
      */
     protected function loadConfig(
         array $requiredKeys = [],
-        bool $processValues = true
+        bool $processValues = true,
     ): Config\Config {
         $configFile = $this->cache->getConfigFile();
 


### PR DESCRIPTION
Normally, it's not desired to process all placeholder values in asset configurations when reading or validating configuration. Therefore, this is now disabled by default, but can be explicitly enabled by passing the `--process-values` option to the `config` command.