### PR TITLE
[!!!][BUGFIX] Return only existing and processed assets from handler

### DIFF
--- a/src/Command/FetchAssetsCommand.php
+++ b/src/Command/FetchAssetsCommand.php
@@ -200,12 +200,6 @@ final class FetchAssetsCommand extends BaseAssetsCommand
             return false;
         }
 
-        if (!($asset instanceof Asset\ProcessedAsset)) {
-            $this->io->error('Error while fetching assets: The asset handler was unable to handle this asset source.');
-
-            return false;
-        }
-
         $this->io->success(sprintf('Assets successfully downloaded to %s', $asset->getProcessedTargetPath()));
 
         return true;

--- a/src/Handler/AssetHandler.php
+++ b/src/Handler/AssetHandler.php
@@ -49,7 +49,7 @@ final class AssetHandler implements HandlerInterface
         Asset\Definition\Source $source,
         Asset\Definition\Target $target,
         Strategy\Strategy $strategy = null,
-    ): Asset\Asset {
+    ): Asset\ExistingAsset|Asset\ProcessedAsset {
         if (null === $strategy) {
             $strategy = $this->decisionMaker->decide($source, $target);
         }


### PR DESCRIPTION
Since the introduction of union types, we can now limit the return types of `AssetHandler::handle()` to match the actual return types, namely `ExistingAsset` and `ProcessedAsset`. With this modification, an additional safety check in the `fetch` command is removed altogether.