### PR TITLE
[!!!][FEATURE] Allow custom handler implementations

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -25,17 +25,20 @@ namespace CPSIT\FrontendAssetHandler\DependencyInjection;
 
 use CPSIT\FrontendAssetHandler\Asset;
 use CPSIT\FrontendAssetHandler\Config;
-use CPSIT\FrontendAssetHandler\DependencyInjection;
+use CPSIT\FrontendAssetHandler\Handler;
 use CPSIT\FrontendAssetHandler\Processor;
 use CPSIT\FrontendAssetHandler\Provider;
 use CPSIT\FrontendAssetHandler\Value;
 use CPSIT\FrontendAssetHandler\Vcs;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection;
 
-return static function (ContainerConfigurator $configurator, ContainerBuilder $container): void {
+return static function (
+    DependencyInjection\Loader\Configurator\ContainerConfigurator $configurator,
+    DependencyInjection\ContainerBuilder $container,
+): void {
     $container->registerForAutoconfiguration(Config\Loader\ConfigLoaderInterface::class)->addTag('config.loader');
     $container->registerForAutoconfiguration(Config\Writer\ConfigWriterInterface::class)->addTag('config.writer');
+    $container->registerForAutoconfiguration(Handler\HandlerInterface::class)->addTag('asset_handling.handler');
     $container->registerForAutoconfiguration(Processor\ProcessorInterface::class)->addTag('asset_handling.processor');
     $container->registerForAutoconfiguration(Provider\ProviderInterface::class)->addTag('asset_handling.provider');
     $container->registerForAutoconfiguration(Value\Placeholder\PlaceholderProcessorInterface::class)->addTag('value.placeholder_processor');
@@ -43,5 +46,5 @@ return static function (ContainerConfigurator $configurator, ContainerBuilder $c
     $container->registerForAutoconfiguration(Vcs\VcsProviderInterface::class)->addTag('asset_handling.vcs_provider');
 
     // Compiler passes
-    $container->addCompilerPass(new DependencyInjection\CompilerPass\EnvironmentTransformerCompilerPass());
+    $container->addCompilerPass(new CompilerPass\EnvironmentTransformerCompilerPass());
 };

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -17,7 +17,6 @@ services:
       - '../src/Console/*'
       - '../src/Exception/*'
       - '../src/DependencyInjection/*'
-      - '../src/Handler/*'
       - '../src/Vcs/Dto/*'
 
   _instanceof:
@@ -44,6 +43,11 @@ services:
     arguments:
       $loaders: !tagged_iterator config.loader
       $writers: !tagged_iterator config.writer
+
+  CPSIT\FrontendAssetHandler\Handler\HandlerFactory:
+    public: true
+    arguments:
+      $handlers: !tagged_locator { tag: 'asset_handling.handler', default_index_method: 'getName' }
 
   CPSIT\FrontendAssetHandler\Provider\ProviderFactory:
     public: true

--- a/config/services_test.php
+++ b/config/services_test.php
@@ -23,10 +23,11 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\DependencyInjection;
 
-use CPSIT\FrontendAssetHandler\DependencyInjection\CompilerPass\PublicServicePass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection;
 
-return static function (ContainerConfigurator $configurator, ContainerBuilder $container): void {
-    $container->addCompilerPass(new PublicServicePass());
+return static function (
+    DependencyInjection\Loader\Configurator\ContainerConfigurator $configurator,
+    DependencyInjection\ContainerBuilder $container,
+): void {
+    $container->addCompilerPass(new CompilerPass\PublicServicePass());
 };

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -4,5 +4,7 @@ services:
     autoconfigure: true
     public: false
 
+  CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyDecisionMaker:
+  CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyHandler:
   CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyProvider:
   CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyProcessor:

--- a/docs/config/full-reference.md
+++ b/docs/config/full-reference.md
@@ -25,7 +25,8 @@ by external asset handlers.
             "environments": {
                 "merge": "<merge>",
                 "map": "<map>"
-            }
+            },
+            "handler": "<type>"
         }
     ]
 }

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -31,6 +31,16 @@
     ```
   - See [Configuration](config/index.md) for all available configuration options
     and check out the updated [schema file](../resources/configuration.schema.json).
+* Asset handlers are now configurable.
+  - Implement the [`HandlerInterface`](../src/Handler/HandlerInterface.php) for custom handlers.
+  - Reference the handler type within the asset definition:
+    ```diff
+     {
+    +    "handler": "my-custom-handler",
+         "source": { /* ... */ },
+         "target": { /* ... */ }
+     }
+    ```
 * Minimum PHP version is now 8.1.
   - Upgrade your code base to PHP 8.1.
 

--- a/docs/usage/api-usage.md
+++ b/docs/usage/api-usage.md
@@ -4,12 +4,10 @@ If asset handling is to be performed via PHP, the following steps are generally 
 
 1. Declare the config file
 2. Get the current container instance
-3. Fetch a Provider using the [`ProviderFactory`](../../src/Provider/ProviderFactory.php)
-4. Fetch a Processor using the [`ProcessorFactory`](../../src/Processor/ProcessorFactory.php)
-5. Instantiate a Handler that is suitable for Provider and Processor
-6. Resolve the requested asset environment
-7. Define [asset source](../config/source.md) and [asset target](../config/target.md)
-8. Execute the Handler, optionally with a freely selectable download strategy
+3. Resolve the requested asset environment
+4. Define [asset source](../config/source.md) and [asset target](../config/target.md)
+5. Fetch a Handler using the [`HandlerFactory`](../../src/Handler/HandlerFactory.php)
+6. Execute the Handler, optionally with a freely selectable download strategy
 
 ## Example
 
@@ -23,11 +21,9 @@ use CPSIT\FrontendAssetHandler\Provider;
 // Declare config file
 $configFile = '/path/to/assets.json';
 
-// Get services from container
+// Get the current service container
 $containerFactory = new DependencyInjection\ContainerFactory($configFile);
 $container = $containerFactory->get();
-$providerFactory = $container->get(Provider\ProviderFactory::class);
-$processorFactory = $container->get(Processor\ProcessorFactory::class);
 
 // Resolve environment
 $map = Asset\Environment\Map\MapFactory::createDefault();
@@ -46,9 +42,8 @@ $target = new Asset\Definition\Target([
 ]);
 
 // Instantiate components
-$provider = $providerFactory->get($source->getType());
-$processor = $processorFactory->get($target->getType());
-$handler = new Handler\AssetHandler($provider, $processor, $processorFactory);
+$handlerFactory = $container->get(Handler\HandlerFactory::class);
+$handler = $handlerFactory->get('default');
 
 // Optional: Define download strategy
 // $strategy = new \CPSIT\FrontendAssetHandler\Strategy\Strategy(\CPSIT\FrontendAssetHandler\Strategy\Strategy::FETCH_NEW);

--- a/resources/configuration.schema.json
+++ b/resources/configuration.schema.json
@@ -38,6 +38,9 @@
 				},
 				"environments": {
 					"$ref": "#/definitions/environments"
+				},
+				"handler": {
+					"$ref": "#/definitions/handler"
 				}
 			}
 		},
@@ -162,6 +165,12 @@
 					}
 				}
 			}
+		},
+		"handler": {
+			"type": "string",
+			"title": "Frontend asset handler type",
+			"description": "Type of a concrete Frontend asset handler (an appropriate Handler must exist).",
+			"default": "default"
 		}
 	}
 }

--- a/src/Command/FetchAssetsCommand.php
+++ b/src/Command/FetchAssetsCommand.php
@@ -29,8 +29,6 @@ use CPSIT\FrontendAssetHandler\DependencyInjection;
 use CPSIT\FrontendAssetHandler\Exception;
 use CPSIT\FrontendAssetHandler\Handler;
 use CPSIT\FrontendAssetHandler\Helper;
-use CPSIT\FrontendAssetHandler\Processor;
-use CPSIT\FrontendAssetHandler\Provider;
 use CPSIT\FrontendAssetHandler\Strategy;
 use Symfony\Component\Console;
 
@@ -53,9 +51,7 @@ final class FetchAssetsCommand extends BaseAssetsCommand
         DependencyInjection\Cache\ContainerCache $cache,
         Config\ConfigFacade $configFacade,
         Config\Parser\Parser $configParser,
-        private readonly Provider\ProviderFactory $providerFactory,
-        private readonly Processor\ProcessorFactory $processorFactory,
-        private readonly Strategy\DecisionMaker $decisionMaker,
+        private readonly Handler\HandlerFactory $handlerFactory,
         private readonly Asset\Definition\AssetDefinitionFactory $assetDefinitionFactory,
     ) {
         parent::__construct('fetch', $cache, $configFacade, $configParser);
@@ -77,22 +73,24 @@ final class FetchAssetsCommand extends BaseAssetsCommand
             'force',
             'f',
             Console\Input\InputOption::VALUE_NONE,
-            'Force fresh download of Frontend assets even if local assets are alread up to date.'
+            'Force fresh download of Frontend assets even if local assets are already up to date.',
         );
         $this->addOption(
             'failsafe',
             's',
             Console\Input\InputOption::VALUE_NONE,
-            'Fall back to latest assets if download for the given environment fails.'
+            'Fall back to latest assets if download for the given environment fails.',
         );
+    }
+
+    protected function initialize(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): void
+    {
+        $this->io = new Console\Style\SymfonyStyle($input, $output);
+        $this->handlerFactory->setOutput($output);
     }
 
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
-        $this->io = new Console\Style\SymfonyStyle($input, $output);
-        $this->providerFactory->setOutput($output);
-        $this->processorFactory->setOutput($output);
-
         $successful = true;
         $branch = $input->getArgument('branch');
 
@@ -124,6 +122,9 @@ final class FetchAssetsCommand extends BaseAssetsCommand
                 $this->io->section(sprintf('Processing of <info>asset definition #%d</info>', $key + 1));
             }
 
+            // Create handler
+            $handler = $this->handlerFactory->get($assetDefinition['handler'] ?? 'default');
+
             // Create source and target
             $source = $this->assetDefinitionFactory->buildSource($assetDefinition, $branch);
             $target = $this->assetDefinitionFactory->buildTarget($assetDefinition);
@@ -149,7 +150,7 @@ final class FetchAssetsCommand extends BaseAssetsCommand
             );
 
             // Perform asset handling
-            if (!$this->performAssetHandling($source, $target, $strategy, $input->getOption('failsafe'))) {
+            if (!$this->performAssetHandling($handler, $source, $target, $strategy, $input->getOption('failsafe'))) {
                 $successful = false;
             }
         }
@@ -164,15 +165,12 @@ final class FetchAssetsCommand extends BaseAssetsCommand
     }
 
     private function performAssetHandling(
+        Handler\HandlerInterface $handler,
         Asset\Definition\Source $source,
         Asset\Definition\Target $target,
         Strategy\Strategy $strategy = null,
         bool $failsafe = false
     ): bool {
-        $provider = $this->providerFactory->get($source->getType());
-        $processor = $this->processorFactory->get($target->getType());
-        $handler = new Handler\AssetHandler($provider, $processor, $this->processorFactory, $this->decisionMaker);
-
         try {
             $asset = $handler->handle($source, $target, $strategy);
         } catch (Exception\DownloadFailedException $exception) {
@@ -186,7 +184,7 @@ final class FetchAssetsCommand extends BaseAssetsCommand
 
             $source['environment'] = Asset\Environment\Environment::Latest->value;
 
-            return $this->performAssetHandling($source, $target);
+            return $this->performAssetHandling($handler, $source, $target);
         }
 
         if ($asset instanceof Asset\ExistingAsset) {
@@ -196,6 +194,12 @@ final class FetchAssetsCommand extends BaseAssetsCommand
                     null !== $asset->getRevision() ? ' of revision '.$asset->getRevision()->getShort() : ''
                 )
             );
+
+            return false;
+        }
+
+        if (!($asset instanceof Asset\ProcessedAsset)) {
+            $this->io->error('Error while fetching assets: The asset handler was unable to handle this asset source.');
 
             return false;
         }

--- a/src/Handler/HandlerFactory.php
+++ b/src/Handler/HandlerFactory.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Handler;
+
+use CPSIT\FrontendAssetHandler\ChattyInterface;
+use CPSIT\FrontendAssetHandler\Exception;
+use Symfony\Component\Console;
+use Symfony\Component\DependencyInjection;
+
+/**
+ * HandlerFactory.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class HandlerFactory
+{
+    private ?Console\Output\OutputInterface $output = null;
+
+    public function __construct(
+        private readonly DependencyInjection\ServiceLocator $handlers,
+    ) {
+    }
+
+    /**
+     * @throws Exception\UnsupportedClassException
+     * @throws Exception\UnsupportedTypeException
+     */
+    public function get(string $type): HandlerInterface
+    {
+        if (!$this->has($type)) {
+            throw Exception\UnsupportedTypeException::create($type);
+        }
+
+        // Fetch handler instance
+        $handler = $this->handlers->get($type);
+
+        // Validate handler instance
+        if (!($handler instanceof HandlerInterface)) {
+            throw Exception\UnsupportedClassException::create($handler::class);
+        }
+
+        // Pass output to handler
+        if ($handler instanceof ChattyInterface && null !== $this->output) {
+            $handler->setOutput($this->output);
+        }
+
+        return $handler;
+    }
+
+    public function has(string $type): bool
+    {
+        return $this->handlers->has($type);
+    }
+
+    public function setOutput(Console\Output\OutputInterface $output): self
+    {
+        $this->output = $output;
+
+        return $this;
+    }
+}

--- a/tests/Unit/Fixtures/Classes/DummyHandler.php
+++ b/tests/Unit/Fixtures/Classes/DummyHandler.php
@@ -21,24 +21,41 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\FrontendAssetHandler\Handler;
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes;
 
 use CPSIT\FrontendAssetHandler\Asset;
+use CPSIT\FrontendAssetHandler\ChattyInterface;
+use CPSIT\FrontendAssetHandler\Handler;
 use CPSIT\FrontendAssetHandler\Strategy;
+use Symfony\Component\Console;
 
 /**
- * HandlerInterface.
+ * DummyHandler.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @internal
  */
-interface HandlerInterface
+final class DummyHandler implements Handler\HandlerInterface, ChattyInterface
 {
+    public ?Console\Output\OutputInterface $output = null;
+
+    public static function getName(): string
+    {
+        return 'dummy';
+    }
+
     public function handle(
         Asset\Definition\Source $source,
         Asset\Definition\Target $target,
         Strategy\Strategy $strategy = null,
-    ): Asset\Asset;
+    ): Asset\Asset {
+        return new Asset\Asset($source, $target);
+    }
 
-    public static function getName(): string;
+    public function setOutput(Console\Output\OutputInterface $output): void
+    {
+        $this->output = $output;
+    }
 }

--- a/tests/Unit/Handler/HandlerFactoryTest.php
+++ b/tests/Unit/Handler/HandlerFactoryTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Handler;
+
+use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Handler;
+use CPSIT\FrontendAssetHandler\Tests;
+use Symfony\Component\Console;
+use Symfony\Component\DependencyInjection;
+
+/**
+ * HandlerFactoryTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class HandlerFactoryTest extends Tests\Unit\ContainerAwareTestCase
+{
+    private Console\Output\NullOutput $output;
+    private Handler\HandlerFactory $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->output = new Console\Output\NullOutput();
+        $this->subject = new Handler\HandlerFactory(
+            new DependencyInjection\ServiceLocator([
+                // Default handler
+                'default' => fn () => $this->container->get(Handler\AssetHandler::class),
+                // Dummy handlers
+                'dummy' => fn () => new Tests\Unit\Fixtures\Classes\DummyHandler(),
+                'invalid' => fn () => new \Exception(),
+            ])
+        );
+        $this->subject->setOutput($this->output);
+    }
+
+    /**
+     * @test
+     */
+    public function getThrowsExceptionIfGivenTypeIsNotSupported(): void
+    {
+        $this->expectExceptionObject(Exception\UnsupportedTypeException::create('foo'));
+
+        $this->subject->get('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function getThrowsExceptionIfResolvedProviderClassIsInvalid(): void
+    {
+        $this->expectExceptionObject(Exception\UnsupportedClassException::create(\Exception::class));
+
+        $this->subject->get('invalid');
+    }
+
+    /**
+     * @test
+     */
+    public function getReturnsInstantiatedProviderOfGivenType(): void
+    {
+        $actual = $this->subject->get('dummy');
+
+        self::assertInstanceOf(Tests\Unit\Fixtures\Classes\DummyHandler::class, $actual);
+        self::assertSame($this->output, $actual->output);
+    }
+
+    /**
+     * @test
+     */
+    public function hasReturnsTrueIfGivenTypeIsAvailable(): void
+    {
+        self::assertTrue($this->subject->has('dummy'));
+        self::assertFalse($this->subject->has('foo'));
+    }
+}


### PR DESCRIPTION
With this PR, consumers can now provide custom handler implementations. For this, a `HandlerFactory` has been introduced with the default `AssetHandler` configured as type `default`. Custom handlers implementing the `HandlerInterface` can therefore be used within the asset handling process. For this, they must be explicitly configured in the asset definition:

```diff
 {
+    "handler": "my-custom-handler",
     "source": { /* ... */ },
     "target": { /* ... */ }
 }
```