### PR TITLE
[BUGFIX] Streamline output handling of chatty classes

### DIFF
--- a/src/Handler/AssetHandler.php
+++ b/src/Handler/AssetHandler.php
@@ -24,10 +24,13 @@ declare(strict_types=1);
 namespace CPSIT\FrontendAssetHandler\Handler;
 
 use CPSIT\FrontendAssetHandler\Asset;
+use CPSIT\FrontendAssetHandler\ChattyInterface;
 use CPSIT\FrontendAssetHandler\Exception;
 use CPSIT\FrontendAssetHandler\Processor;
 use CPSIT\FrontendAssetHandler\Provider;
 use CPSIT\FrontendAssetHandler\Strategy;
+use CPSIT\FrontendAssetHandler\Traits;
+use Symfony\Component\Console;
 
 /**
  * AssetHandler.
@@ -35,13 +38,18 @@ use CPSIT\FrontendAssetHandler\Strategy;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class AssetHandler implements HandlerInterface
+final class AssetHandler implements HandlerInterface, ChattyInterface
 {
+    use Traits\OutputAwareTrait {
+        setOutput as private doSetOutput;
+    }
+
     public function __construct(
         private readonly Provider\ProviderFactory $providerFactory,
         private readonly Processor\ProcessorFactory $processorFactory,
         private readonly Strategy\DecisionMaker $decisionMaker,
     ) {
+        $this->setOutput(new Console\Output\NullOutput());
     }
 
     public static function getName(): string
@@ -87,5 +95,13 @@ final class AssetHandler implements HandlerInterface
         }
 
         return new Asset\ProcessedAsset($source, $target, $processedTargetPath);
+    }
+
+    public function setOutput(Console\Output\OutputInterface $output): void
+    {
+        $this->doSetOutput($output);
+
+        $this->providerFactory->setOutput($this->output);
+        $this->processorFactory->setOutput($this->output);
     }
 }

--- a/src/Handler/HandlerFactory.php
+++ b/src/Handler/HandlerFactory.php
@@ -25,6 +25,7 @@ namespace CPSIT\FrontendAssetHandler\Handler;
 
 use CPSIT\FrontendAssetHandler\ChattyInterface;
 use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Traits;
 use Symfony\Component\Console;
 use Symfony\Component\DependencyInjection;
 
@@ -34,13 +35,14 @@ use Symfony\Component\DependencyInjection;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class HandlerFactory
+final class HandlerFactory implements ChattyInterface
 {
-    private ?Console\Output\OutputInterface $output = null;
+    use Traits\OutputAwareTrait;
 
     public function __construct(
         private readonly DependencyInjection\ServiceLocator $handlers,
     ) {
+        $this->setOutput(new Console\Output\NullOutput());
     }
 
     /**
@@ -62,7 +64,7 @@ final class HandlerFactory
         }
 
         // Pass output to handler
-        if ($handler instanceof ChattyInterface && null !== $this->output) {
+        if ($handler instanceof ChattyInterface) {
             $handler->setOutput($this->output);
         }
 
@@ -72,12 +74,5 @@ final class HandlerFactory
     public function has(string $type): bool
     {
         return $this->handlers->has($type);
-    }
-
-    public function setOutput(Console\Output\OutputInterface $output): self
-    {
-        $this->output = $output;
-
-        return $this;
     }
 }

--- a/src/Processor/ProcessorFactory.php
+++ b/src/Processor/ProcessorFactory.php
@@ -25,6 +25,7 @@ namespace CPSIT\FrontendAssetHandler\Processor;
 
 use CPSIT\FrontendAssetHandler\ChattyInterface;
 use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Traits;
 use Symfony\Component\Console;
 use Symfony\Component\DependencyInjection;
 
@@ -36,11 +37,12 @@ use Symfony\Component\DependencyInjection;
  */
 final class ProcessorFactory implements ChattyInterface
 {
-    private ?Console\Output\OutputInterface $output = null;
+    use Traits\OutputAwareTrait;
 
     public function __construct(
         private readonly DependencyInjection\ServiceLocator $processors,
     ) {
+        $this->setOutput(new Console\Output\NullOutput());
     }
 
     /**
@@ -62,7 +64,7 @@ final class ProcessorFactory implements ChattyInterface
         }
 
         // Pass output to chatty processor
-        if ($processor instanceof ChattyInterface && null !== $this->output) {
+        if ($processor instanceof ChattyInterface) {
             $processor->setOutput($this->output);
         }
 
@@ -72,10 +74,5 @@ final class ProcessorFactory implements ChattyInterface
     public function has(string $type): bool
     {
         return $this->processors->has($type);
-    }
-
-    public function setOutput(Console\Output\OutputInterface $output): void
-    {
-        $this->output = $output;
     }
 }

--- a/src/Provider/ProviderFactory.php
+++ b/src/Provider/ProviderFactory.php
@@ -25,6 +25,7 @@ namespace CPSIT\FrontendAssetHandler\Provider;
 
 use CPSIT\FrontendAssetHandler\ChattyInterface;
 use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Traits;
 use Symfony\Component\Console;
 use Symfony\Component\DependencyInjection;
 
@@ -34,13 +35,14 @@ use Symfony\Component\DependencyInjection;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class ProviderFactory
+final class ProviderFactory implements ChattyInterface
 {
-    private ?Console\Output\OutputInterface $output = null;
+    use Traits\OutputAwareTrait;
 
     public function __construct(
         private readonly DependencyInjection\ServiceLocator $providers,
     ) {
+        $this->setOutput(new Console\Output\NullOutput());
     }
 
     /**
@@ -62,7 +64,7 @@ final class ProviderFactory
         }
 
         // Pass output to chatty providers
-        if ($provider instanceof ChattyInterface && null !== $this->output) {
+        if ($provider instanceof ChattyInterface) {
             $provider->setOutput($this->output);
         }
 
@@ -72,12 +74,5 @@ final class ProviderFactory
     public function has(string $type): bool
     {
         return $this->providers->has($type);
-    }
-
-    public function setOutput(Console\Output\OutputInterface $output): self
-    {
-        $this->output = $output;
-
-        return $this;
     }
 }

--- a/tests/Unit/Fixtures/Classes/DummyProvider.php
+++ b/tests/Unit/Fixtures/Classes/DummyProvider.php
@@ -48,6 +48,11 @@ final class DummyProvider implements Provider\ProviderInterface, ChattyInterface
      */
     public array $expectedExceptions = [];
 
+    /**
+     * @var list<Asset\Asset>
+     */
+    public array $expectedAssets = [];
+
     public static function getName(): string
     {
         return 'dummy';
@@ -57,6 +62,10 @@ final class DummyProvider implements Provider\ProviderInterface, ChattyInterface
     {
         if ([] !== $this->expectedExceptions) {
             throw array_shift($this->expectedExceptions);
+        }
+
+        if ([] !== $this->expectedAssets) {
+            return array_shift($this->expectedAssets);
         }
 
         return new Asset\Asset($source);

--- a/tests/Unit/Handler/HandlerFactoryTest.php
+++ b/tests/Unit/Handler/HandlerFactoryTest.php
@@ -23,10 +23,11 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Tests\Unit\Handler;
 
+use CPSIT\FrontendAssetHandler\Console;
 use CPSIT\FrontendAssetHandler\Exception;
 use CPSIT\FrontendAssetHandler\Handler;
 use CPSIT\FrontendAssetHandler\Tests;
-use Symfony\Component\Console;
+use Symfony\Component\Console as SymfonyConsole;
 use Symfony\Component\DependencyInjection;
 
 /**
@@ -37,14 +38,14 @@ use Symfony\Component\DependencyInjection;
  */
 final class HandlerFactoryTest extends Tests\Unit\ContainerAwareTestCase
 {
-    private Console\Output\NullOutput $output;
+    private SymfonyConsole\Output\NullOutput $output;
     private Handler\HandlerFactory $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->output = new Console\Output\NullOutput();
+        $this->output = new SymfonyConsole\Output\NullOutput();
         $this->subject = new Handler\HandlerFactory(
             new DependencyInjection\ServiceLocator([
                 // Default handler
@@ -85,7 +86,18 @@ final class HandlerFactoryTest extends Tests\Unit\ContainerAwareTestCase
         $actual = $this->subject->get('dummy');
 
         self::assertInstanceOf(Tests\Unit\Fixtures\Classes\DummyHandler::class, $actual);
-        self::assertSame($this->output, $actual->output);
+    }
+
+    /**
+     * @test
+     */
+    public function getAppliesOutputToChattyHandlers(): void
+    {
+        $actual = $this->subject->get('dummy');
+
+        self::assertInstanceOf(Tests\Unit\Fixtures\Classes\DummyHandler::class, $actual);
+        self::assertInstanceOf(Console\Output\TrackableOutput::class, $actual->output);
+        self::assertSame($this->output, $actual->output->getOutput());
     }
 
     /**


### PR DESCRIPTION
With this PR, all classes implementing the `ChattyInterface` now make use of the provided `OutputAwareTrait` in order to streamline handling of output-aware classes. Additionally, this fixes an issue introduced with #12 where the original output is not passed to the final providers and processors.