### PR TITLE
[BUGFIX] Handle multiple environment variable placeholders

### DIFF
--- a/tests/Unit/Value/Placeholder/EnvironmentVariableProcessorTest.php
+++ b/tests/Unit/Value/Placeholder/EnvironmentVariableProcessorTest.php
@@ -28,6 +28,8 @@ use CPSIT\FrontendAssetHandler\Value\Placeholder\EnvironmentVariableProcessor;
 use Generator;
 use UnexpectedValueException;
 
+use function putenv;
+
 /**
  * EnvironmentVariableProcessorTest.
  *
@@ -88,11 +90,15 @@ final class EnvironmentVariableProcessorTest extends ContainerAwareTestCase
     public function processReplacesEnvironmentPlaceholderWithEnvironmentVariable(string $placeholder, string $expected): void
     {
         putenv('foo=baz');
+        putenv('baz=boo');
+        putenv('dummy=New York');
 
         self::assertSame($expected, $this->subject->process($placeholder));
 
         // Unset temporary environment variable
         putenv('foo');
+        putenv('baz');
+        putenv('dummy');
     }
 
     /**
@@ -113,6 +119,10 @@ final class EnvironmentVariableProcessorTest extends ContainerAwareTestCase
     public function processReplacesEnvironmentPlaceholderWithEnvironmentVariableDataProvider(): Generator
     {
         yield 'placeholder only' => ['%env(foo)%', 'baz'];
-        yield 'placeholder with surrounding text' => ['Hello, %env(foo)%!', 'Hello, baz!'];
+        yield 'one placeholder with surrounding text' => ['Hello, %env(foo)%!', 'Hello, baz!'];
+        yield 'multiple placeholders with surrounding text' => [
+            'Hello, %env(foo)% %env(baz)%! Welcome to %env(dummy)%.',
+            'Hello, baz boo! Welcome to New York.',
+        ];
     }
 }


### PR DESCRIPTION
Prior to this PR, only the first environment variable placeholder was matched and all subsequent placeholders were replaced with the resolved environment variable of the first match. With this PR, `preg_match_all` is now used instead of `preg_match` in order to properly process all environment variable placeholders.

Resolves: #16