### PR TITLE
[FEATURE] Introduce configuration initialization steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ a dedicated CLI application.
   - Command-line usage
     + [Configure assets](docs/usage/cli-config-assets.md)
     + [Fetch assets](docs/usage/cli-fetch-assets.md)
+    + [Initialize config](docs/usage/cli-init-config.md)
     + [Inspect assets](docs/usage/cli-inspect-assets.md)
   - [API usage](docs/usage/api-usage.md)
 * [Configuration](docs/config/index.md)

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
 		"phpstan/phpstan": "^1.2",
 		"phpstan/phpstan-phpunit": "^1.0",
 		"phpstan/phpstan-symfony": "^1.1",
+		"phpstan/phpstan-webmozart-assert": "^1.2",
 		"phpunit/phpunit": "^9.5.5",
 		"rector/rector": "^0.14.0"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06191786f067b7d71fde3dd11684069c",
+    "content-hash": "e890cc54378889b4ce694f50ebd54ed8",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",
@@ -3265,6 +3265,56 @@
                 "source": "https://github.com/phpstan/phpstan-symfony/tree/1.2.13"
             },
             "time": "2022-08-28T13:34:45+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-webmozart-assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-webmozart-assert.git",
+                "reference": "a7f12958f0c5e1f948df99a84aa03fa8df544992"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-webmozart-assert/zipball/a7f12958f0c5e1f948df99a84aa03fa8df544992",
+                "reference": "a7f12958f0c5e1f948df99a84aa03fa8df544992",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.6.4"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "webmozart/assert": "^1.11.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan webmozart/assert extension",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-webmozart-assert/issues",
+                "source": "https://github.com/phpstan/phpstan-webmozart-assert/tree/1.2.0"
+            },
+            "time": "2022-06-06T08:42:28+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -12,6 +12,7 @@ services:
       - '../src/Asset/Environment/EnvironmentResolver.php'
       - '../src/Asset/Revision/Revision.php'
       - '../src/Asset/*Asset.php'
+      - '../src/Config/Initialization/InitializationRequest.php'
       - '../src/Config/Parser/ParserInstructions.php'
       - '../src/Config/Config.php'
       - '../src/Console/*'
@@ -32,12 +33,30 @@ services:
     arguments:
       $transformers: '%asset_environment.transformers%'
 
-  CPSIT\FrontendAssetHandler\Command\InitConfigCommand:
+  CPSIT\FrontendAssetHandler\Config\Initialization\Step\HandlerConfigStep:
     arguments:
       $handlers: !tagged_locator { tag: 'asset_handling.handler', default_index_method: 'getName' }
-      $processors: !tagged_locator { tag: 'asset_handling.processor', default_index_method: 'getName' }
+
+  CPSIT\FrontendAssetHandler\Config\Initialization\Step\SourceConfigStep:
+    arguments:
       $providers: !tagged_locator { tag: 'asset_handling.provider', default_index_method: 'getName' }
+
+  CPSIT\FrontendAssetHandler\Config\Initialization\Step\TargetConfigStep:
+    arguments:
+      $processors: !tagged_locator { tag: 'asset_handling.processor', default_index_method: 'getName' }
+
+  CPSIT\FrontendAssetHandler\Config\Initialization\Step\VcsConfigStep:
+    arguments:
       $vcsProviders: !tagged_locator { tag: 'asset_handling.vcs_provider', default_index_method: 'getName' }
+
+  CPSIT\FrontendAssetHandler\Command\InitConfigCommand:
+    arguments:
+      $initSteps:
+        - '@CPSIT\FrontendAssetHandler\Config\Initialization\Step\ConfigFileStep'
+        - '@CPSIT\FrontendAssetHandler\Config\Initialization\Step\SourceConfigStep'
+        - '@CPSIT\FrontendAssetHandler\Config\Initialization\Step\TargetConfigStep'
+        - '@CPSIT\FrontendAssetHandler\Config\Initialization\Step\HandlerConfigStep'
+        - '@CPSIT\FrontendAssetHandler\Config\Initialization\Step\VcsConfigStep'
 
   CPSIT\FrontendAssetHandler\Config\ConfigFacade:
     public: true

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -4,8 +4,16 @@ services:
     autoconfigure: true
     public: false
 
+  CPSIT\FrontendAssetHandler\Command\InitConfigCommand:
+    arguments:
+      $initSteps:
+        - '@CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyStep'
+        - '@CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyInteractiveStep'
+
   CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyDecisionMaker:
   CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyHandler:
+  CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyInteractiveStep:
   CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyProvider:
   CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyProcessor:
   CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyRevisionProvider:
+  CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes\DummyStep:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,7 @@ includes:
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-symfony/extension.neon
+	- vendor/phpstan/phpstan-webmozart-assert/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/src/Command/InitConfigCommand.php
+++ b/src/Command/InitConfigCommand.php
@@ -23,21 +23,14 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Command;
 
-use CPSIT\FrontendAssetHandler\Asset;
+use CPSIT\FrontendAssetHandler\ChattyInterface;
 use CPSIT\FrontendAssetHandler\Config;
-use CPSIT\FrontendAssetHandler\Console;
 use CPSIT\FrontendAssetHandler\Exception;
-use CPSIT\FrontendAssetHandler\Helper;
 use CPSIT\FrontendAssetHandler\Json;
-use Symfony\Component\Console as SymfonyConsole;
-use Symfony\Component\DependencyInjection;
+use JsonException;
+use Symfony\Component\Console;
 
-use function array_key_last;
-use function array_merge;
-use function json_decode;
 use function sprintf;
-use function str_starts_with;
-use function strtolower;
 
 /**
  * InitConfigCommand.
@@ -45,20 +38,20 @@ use function strtolower;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class InitConfigCommand extends SymfonyConsole\Command\Command
+final class InitConfigCommand extends Console\Command\Command
 {
     private const SUCCESSFUL = 0;
+    private const ERROR_FAILED_ACTION = 1;
 
-    private SymfonyConsole\Style\SymfonyStyle $io;
+    private Console\Style\SymfonyStyle $io;
 
+    /**
+     * @param non-empty-list<Config\Initialization\Step\StepInterface> $initSteps
+     */
     public function __construct(
+        private readonly array $initSteps,
         private readonly Config\ConfigFacade $configFacade,
-        private readonly Config\Parser\Parser $configParser,
         private readonly Json\SchemaValidator $validator,
-        private readonly DependencyInjection\ServiceLocator $handlers,
-        private readonly DependencyInjection\ServiceLocator $processors,
-        private readonly DependencyInjection\ServiceLocator $providers,
-        private readonly DependencyInjection\ServiceLocator $vcsProviders,
     ) {
         parent::__construct('init');
     }
@@ -67,362 +60,84 @@ final class InitConfigCommand extends SymfonyConsole\Command\Command
     {
         $this->setDescription('Initialize a new configuration file to handle Frontend assets');
 
-        $this->addOption(
-            'source-type',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Type of the asset source, resolves to a supported asset provider',
-        );
-        $this->addOption(
-            'source-url',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'URL to locate the asset source files, can contain placeholders in the form {<config key>}',
-        );
-        $this->addOption(
-            'source-revision-url',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'URL to locate the revision of asset source files, can contain placeholders in the form {<config key>}',
-        );
-        $this->addOption(
-            'source-config-extra',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Additional configuration for the asset source definition, should be a JSON-encoded string',
-        );
-
-        $this->addOption(
-            'target-type',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Type of the asset target, resolves to a supported asset processor',
-        );
-        $this->addOption(
-            'target-path',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Path where to extract fetched assets, can be either absolute or relative to the config file',
-        );
-        $this->addOption(
-            'target-revision-file',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Filename of the asset target\'s revision file',
-            Asset\Definition\Target::DEFAULT_REVISION_FILE,
-        );
-        $this->addOption(
-            'target-config-extra',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Additional configuration for the asset target definition, should be a JSON-encoded string',
-        );
-
-        $this->addOption(
-            'handler-type',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Type of the asset handler, resolves to a supported asset handler',
-        );
-
-        $this->addOption(
-            'vcs-type',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Type of the asset\'s VCS, resolves to a supported VCS provider',
-        );
-        $this->addOption(
-            'vcs-config-extra',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'Additional configuration for the asset VCS definition, should be a JSON-encoded string',
-        );
-
-        $this->addOption(
-            'definition-id',
-            null,
-            SymfonyConsole\Input\InputOption::VALUE_REQUIRED,
-            'ID of the asset definition to be added to the asset configuration file',
-            0,
-        );
+        $this->addOptionsFromConfigurableInitSteps();
     }
 
-    protected function initialize(SymfonyConsole\Input\InputInterface $input, SymfonyConsole\Output\OutputInterface $output): void
+    protected function initialize(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): void
     {
-        $this->io = new SymfonyConsole\Style\SymfonyStyle($input, $output);
+        $this->io = new Console\Style\SymfonyStyle($input, $output);
     }
 
-    protected function interact(SymfonyConsole\Input\InputInterface $input, SymfonyConsole\Output\OutputInterface $output): void
+    /**
+     * @throws Exception\InvalidConfigurationException
+     * @throws Exception\MissingConfigurationException
+     * @throws JsonException
+     */
+    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
-        /** @var SymfonyConsole\Helper\QuestionHelper $helper */
-        $helper = $this->getHelper('question');
-
         $output->writeln([
             'Welcome to the Frontend Asset Handler!',
             'You can use the following command to initialize a new asset configuration for your Frontend assets.',
             'Follow the guide and answer all relevant questions to get started.',
         ]);
 
-        $this->selectConfigFileAndDefinitionId($input, $output);
+        $request = Config\Initialization\InitializationRequest::fromCommandInput($input);
 
-        $this->io->title('Source');
+        // Run init steps
+        foreach ($this->initSteps as $step) {
+            if ($step instanceof ChattyInterface) {
+                $step->setOutput($output);
+            }
 
-        $question = $this->createChoiceQuestion(
-            'Type',
-            $this->providers->getProvidedServices(),
-            $input->getOption('source-type'),
-        );
-        $input->setOption('source-type', $helper->ask($input, $output, $question));
-
-        $question = $this->createQuestion('URL', $input->getOption('source-url'));
-        $question->setValidator(Console\Input\Validator\UrlValidator::validate(...));
-        $input->setOption('source-url', $helper->ask($input, $output, $question));
-
-        $question = $this->createQuestion('Revision URL', $input->getOption('source-revision-url'));
-        $question->setValidator(Console\Input\Validator\UrlValidator::validate(...));
-        $input->setOption('source-revision-url', $helper->ask($input, $output, $question));
-
-        $question = $this->createQuestion('Additional config', $input->getOption('source-config-extra'));
-        $question->setValidator(Console\Input\Validator\JsonValidator::validate(...));
-        $input->setOption('source-config-extra', $helper->ask($input, $output, $question));
-
-        $this->io->newLine();
-        $this->io->title('Target');
-
-        $question = $this->createChoiceQuestion(
-            'Type',
-            $this->processors->getProvidedServices(),
-            $input->getOption('target-type'),
-        );
-        $input->setOption('target-type', $helper->ask($input, $output, $question));
-
-        $question = $this->createQuestion('Path', $input->getOption('target-path'));
-        $question->setValidator(Console\Input\Validator\NotEmptyValidator::validate(...));
-        $input->setOption('target-path', $helper->ask($input, $output, $question));
-
-        $question = $this->createQuestion('Revision file', $input->getOption('target-revision-file'));
-        $question->setValidator(Console\Input\Validator\NotEmptyValidator::validate(...));
-        $input->setOption('target-revision-file', $helper->ask($input, $output, $question));
-
-        $question = $this->createQuestion('Additional config', $input->getOption('target-config-extra'));
-        $question->setValidator(Console\Input\Validator\JsonValidator::validate(...));
-        $input->setOption('target-config-extra', $helper->ask($input, $output, $question));
-
-        $this->io->newLine();
-        $this->io->title('Handler');
-
-        $question = $this->createChoiceQuestion(
-            'Handler',
-            $this->handlers->getProvidedServices(),
-            $input->getOption('handler-type'),
-        );
-        $input->setOption('handler-type', $helper->ask($input, $output, $question));
-
-        $this->io->newLine();
-        $this->io->title('VCS');
-
-        $continue = true;
-
-        if (null === $input->getOption('vcs-type')) {
-            $output->writeln('The following VCS configuration is optional.');
-            $question = $this->createQuestion('Add VCS configuration?', 'Y', 'n');
-            $continue = str_starts_with(strtolower((string) $helper->ask($input, $output, $question)), 'y');
-        }
-
-        if (!$continue) {
-            return;
-        }
-
-        $question = $this->createChoiceQuestion(
-            'Type',
-            $this->vcsProviders->getProvidedServices(),
-            $input->getOption('vcs-type'),
-        );
-        $input->setOption('vcs-type', $helper->ask($input, $output, $question));
-
-        $question = $this->createQuestion('Additional config', $input->getOption('vcs-config-extra'));
-        $question->setValidator(Console\Input\Validator\JsonValidator::validate(...));
-        $input->setOption('vcs-config-extra', $helper->ask($input, $output, $question));
-    }
-
-    protected function execute(SymfonyConsole\Input\InputInterface $input, SymfonyConsole\Output\OutputInterface $output): int
-    {
-        if (!$input->isInteractive()) {
-            throw new SymfonyConsole\Exception\RuntimeException('This console command can only be run in interactive mode.', 1662395429);
-        }
-
-        // Resolve config file
-        $configFile = Helper\FilesystemHelper::resolveRelativePath($input->getOption('config'), true);
-        $definitionId = $input->getOption('definition-id');
-
-        // Create config
-        $config = $this->loadConfig($configFile) ?? new Config\Config([], $configFile);
-
-        // Build source
-        $sourceConfigExtra = $input->getOption('source-config-extra');
-        $source = new Asset\Definition\Source(
-            array_merge(
-                [
-                    'type' => $input->getOption('source-type'),
-                    'url' => $input->getOption('source-url'),
-                    'revision-url' => $input->getOption('source-revision-url'),
-                ],
-                null !== $sourceConfigExtra ? json_decode((string) $sourceConfigExtra, true) : [],
-            ),
-        );
-        $config['frontend-assets'][$definitionId]['source'] = $source->getConfig();
-
-        // Build target
-        $targetConfigExtra = $input->getOption('target-config-extra');
-        $target = new Asset\Definition\Target(
-            array_merge(
-                [
-                    'type' => $input->getOption('target-type'),
-                    'path' => $input->getOption('target-path'),
-                    'revision-file' => $input->getOption('target-revision-file'),
-                ],
-                null !== $targetConfigExtra ? json_decode((string) $targetConfigExtra, true) : [],
-            ),
-        );
-        $config['frontend-assets'][$definitionId]['target'] = $target->getConfig();
-
-        // Build handler
-        if (null !== $input->getOption('handler-type')) {
-            $config['frontend-assets'][$definitionId]['handler'] = $input->getOption('handler-type');
-        }
-
-        // Build VCS
-        if ($input->getOption('vcs-type')) {
-            $vcsConfigExtra = $input->getOption('vcs-config-extra');
-            $vcs = new Asset\Definition\Vcs(
-                array_merge(
-                    [
-                        'type' => $input->getOption('vcs-type'),
-                    ],
-                    null !== $vcsConfigExtra ? json_decode((string) $vcsConfigExtra, true) : [],
-                ),
-            );
-            $config['frontend-assets'][$definitionId]['vcs'] = $vcs->getConfig();
+            if (!$step->execute($request)) {
+                return $this->exitOnFailedInitStep($step);
+            }
         }
 
         // Validate config
-        if (!$this->validator->validate($config)) {
+        if (!$this->validator->validate($request->getConfig())) {
             throw Exception\InvalidConfigurationException::asReported($this->validator->getLastValidationErrors()->errors());
         }
 
         // Write config
-        $this->configFacade->write($config);
+        if (!$this->configFacade->write($request->getConfig())) {
+            throw Exception\FilesystemFailureException::forFailedWriteOperation($request->getConfigFile());
+        }
 
         $this->io->newLine();
         $this->io->success(
-            sprintf('Asset configuration was successfully written to %s', $config->getFilePath()),
+            sprintf('Asset configuration was successfully written to %s', $request->getConfigFile()),
         );
 
         return self::SUCCESSFUL;
     }
 
-    private function selectConfigFileAndDefinitionId(
-        SymfonyConsole\Input\InputInterface $input,
-        SymfonyConsole\Output\OutputInterface $output,
-    ): void {
-        /** @var SymfonyConsole\Helper\QuestionHelper $helper */
-        $helper = $this->getHelper('question');
+    private function addOptionsFromConfigurableInitSteps(): void
+    {
+        $fullDefinition = $this->getDefinition();
+        $nativeDefinition = $this->getNativeDefinition();
 
-        // Load config file
-        $configFile = $input->getOption('config');
-        $config = $this->loadConfig($configFile);
+        foreach ($this->initSteps as $step) {
+            if (!($step instanceof Config\Initialization\Step\InteractiveStepInterface)) {
+                continue;
+            }
 
-        // Early return if given config file does not exist yet
-        if (null === $config) {
-            $input->setOption('definition-id', 0);
+            $options = $step->getInputOptions();
 
-            return;
+            // Add options to full and native definition
+            $fullDefinition->addOptions($options);
+            if ($nativeDefinition !== $fullDefinition) {
+                $nativeDefinition->addOptions($options);
+            }
         }
+    }
 
-        $upperDefinitionId = (int) array_key_last($config['frontend-assets']);
-
-        // Early return if given definition id is valid
-        if ((int) $input->getOption('definition-id') > $upperDefinitionId) {
-            $input->setOption('definition-id', $upperDefinitionId + 1);
-
-            return;
-        }
-
-        $output->writeln([
-            '',
-            sprintf('You have configured the file <info>%s</info> for your Frontend assets.', $configFile),
-            sprintf('A file with the name <info>%s</info> already exists.', $configFile),
-            'You can <comment>add a new asset definition</comment> to the existing config file or <comment>create a new config file</comment>.',
-            '',
-        ]);
-
-        $question = $this->createQuestion(
-            sprintf('Add a new asset definition to %s?', $configFile),
-            'Y',
-            'n',
+    private function exitOnFailedInitStep(Config\Initialization\Step\StepInterface $failedAction): int
+    {
+        $this->io->error(
+            sprintf('Action "%s" failed to initialize the configuration.', $failedAction::class),
         );
-        $shouldExtendConfig = str_starts_with(strtolower((string) $helper->ask($input, $output, $question)), 'y');
 
-        // Early return if existing config file should be extended
-        if ($shouldExtendConfig) {
-            $input->setOption('definition-id', $upperDefinitionId + 1);
-
-            $output->writeln([
-                sprintf('Alright, the config file <info>%s</info> will be extended by a new asset definition.', $configFile),
-            ]);
-
-            return;
-        }
-
-        $question = new SymfonyConsole\Question\Question('<info>Path to the new config file</info>: ');
-
-        $input->setOption('config', $helper->ask($input, $output, $question));
-        $input->setOption('definition-id', 0);
-
-        $output->writeln([
-            sprintf('Alright, the config file <info>%s</info> will be used for the new asset definition.', $input->getOption('config')),
-        ]);
-    }
-
-    private function loadConfig(string $configFile): ?Config\Config
-    {
-        try {
-            $config = $this->configFacade->load($configFile);
-        } catch (Exception\FilesystemFailureException) {
-            return null;
-        }
-
-        $instructions = new Config\Parser\ParserInstructions($config);
-        $instructions->processValues(false);
-
-        return $this->configParser->parse($instructions);
-    }
-
-    private function createQuestion(string $label, mixed $default = null, string $alternative = null): SymfonyConsole\Question\Question
-    {
-        $label = $this->decorateQuestionLabel($label, $default, $alternative);
-
-        return new SymfonyConsole\Question\Question($label, $default);
-    }
-
-    /**
-     * @param array<string, string> $choices
-     */
-    private function createChoiceQuestion(string $label, array $choices, mixed $default = null): SymfonyConsole\Question\ChoiceQuestion
-    {
-        $label = $this->decorateQuestionLabel($label, $default);
-
-        return new SymfonyConsole\Question\ChoiceQuestion($label, $choices, $default);
-    }
-
-    private function decorateQuestionLabel(string $label, mixed $default, string $alternative = null): string
-    {
-        $label = sprintf('▶ <info>%s</info>', $label);
-
-        if (null !== $default) {
-            $label .= ' ['.$default.($alternative ? '/'.$alternative : '').']';
-        }
-
-        return $label.': ';
+        return self::ERROR_FAILED_ACTION;
     }
 }

--- a/src/Config/Initialization/InitializationRequest.php
+++ b/src/Config/Initialization/InitializationRequest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Config\Initialization;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Exception;
+use OutOfBoundsException;
+use Symfony\Component\Console;
+
+use function array_key_exists;
+use function is_string;
+use function sprintf;
+
+/**
+ * InitializationRequest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class InitializationRequest
+{
+    private ?Config\Config $config = null;
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        private string $configFile,
+        private array $options = [],
+        private readonly ?Console\Input\InputInterface $input = null,
+    ) {
+    }
+
+    /**
+     * @throws Exception\MissingConfigurationException
+     */
+    public static function fromCommandInput(Console\Input\InputInterface $input): self
+    {
+        $configFile = $input->getOption('config');
+
+        if (!is_string($configFile)) {
+            throw Exception\MissingConfigurationException::create();
+        }
+
+        return new self($configFile, $input->getOptions(), $input);
+    }
+
+    public function getConfig(): Config\Config
+    {
+        if (null === $this->config) {
+            $this->config = new Config\Config([], $this->configFile);
+        }
+
+        return $this->config;
+    }
+
+    public function setConfig(Config\Config $config): self
+    {
+        $this->config = $config;
+        $this->configFile = $config->getFilePath();
+
+        return $this;
+    }
+
+    public function getConfigFile(): string
+    {
+        return $this->configFile;
+    }
+
+    public function setConfigFile(string $configFile): self
+    {
+        $this->configFile = $configFile;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function getOption(string $name): mixed
+    {
+        if (!array_key_exists($name, $this->options)) {
+            throw new OutOfBoundsException(sprintf('The initialization option "%s" does not exist.', $name), 1663086743);
+        }
+
+        return $this->options[$name];
+    }
+
+    public function setOption(string $name, mixed $value): self
+    {
+        $this->options[$name] = $value;
+
+        return $this;
+    }
+
+    public function getInput(): ?Console\Input\InputInterface
+    {
+        return $this->input;
+    }
+}

--- a/src/Config/Initialization/Step/BaseStep.php
+++ b/src/Config/Initialization/Step/BaseStep.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\ChattyInterface;
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Console;
+use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Helper;
+use CPSIT\FrontendAssetHandler\Traits;
+use Symfony\Component\Console as SymfonyConsole;
+
+use function array_diff;
+use function array_keys;
+use function is_array;
+use function is_string;
+use function sprintf;
+use function str_starts_with;
+
+/**
+ * BaseStep.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+abstract class BaseStep implements StepInterface, ChattyInterface
+{
+    use Traits\OutputAwareTrait;
+
+    protected readonly Console\Input\Validator\ValidatorFactory $validatorFactory;
+    protected readonly SymfonyConsole\Helper\QuestionHelper $questionHelper;
+
+    public function __construct()
+    {
+        $this->validatorFactory = new Console\Input\Validator\ValidatorFactory();
+        $this->questionHelper = new SymfonyConsole\Helper\QuestionHelper();
+    }
+
+    /**
+     * @var array<string, Console\Input\Validator\ValidatorInterface>
+     */
+    protected array $validators = [];
+
+    /**
+     * @param string|non-empty-list<string>|null $validator
+     */
+    protected function createQuestion(
+        string $label,
+        mixed $default = null,
+        string $alternative = null,
+        string|array $validator = null,
+    ): SymfonyConsole\Question\Question {
+        $label = $this->decorateQuestionLabel($label, $default, $alternative);
+        $question = new SymfonyConsole\Question\Question($label, $default);
+
+        if (null === $validator) {
+            return $question;
+        }
+
+        return $question->setValidator($this->createValidator($validator)->validate(...));
+    }
+
+    /**
+     * @param array<string, string> $choices
+     */
+    protected function createChoiceQuestion(
+        string $label,
+        array $choices,
+        mixed $default = null,
+    ): SymfonyConsole\Question\ChoiceQuestion {
+        $label = $this->decorateQuestionLabel($label, $default);
+
+        return new SymfonyConsole\Question\ChoiceQuestion($label, $choices, $default);
+    }
+
+    protected function decorateQuestionLabel(string $label, mixed $default, string $alternative = null): string
+    {
+        $label = sprintf('▶ <info>%s</info>', $label);
+
+        if (null !== $default) {
+            $label .= ' ['.$default.($alternative ? '/'.$alternative : '').']';
+        }
+
+        return $label.': ';
+    }
+
+    protected function askBooleanQuestion(
+        Config\Initialization\InitializationRequest $request,
+        string $label,
+    ): bool {
+        $input = $this->getInput($request);
+        $question = $this->createQuestion($label, 'Y', 'n');
+
+        return str_starts_with(strtolower((string) $this->questionHelper->ask($input, $this->output, $question)), 'y');
+    }
+
+    /**
+     * @param array<string, mixed>               $additionalVariables
+     * @param string|non-empty-list<string>|null $validator
+     */
+    protected function askForPlaceholderVariables(
+        Config\Initialization\InitializationRequest $request,
+        mixed $string,
+        string $label,
+        array &$additionalVariables,
+        mixed $default = null,
+        string|array $validator = null,
+    ): void {
+        if (!is_string($string)) {
+            return;
+        }
+
+        $placeholders = array_diff(
+            Helper\StringHelper::extractPlaceholders($string),
+            ['environment', 'revision'],
+            array_keys($request->getOptions()),
+            array_keys($additionalVariables),
+        );
+
+        foreach ($placeholders as $placeholder) {
+            $this->askForAdditionalVariable(
+                $request,
+                sprintf($label, $placeholder),
+                $placeholder,
+                $additionalVariables,
+                $default,
+                $validator,
+            );
+        }
+    }
+
+    /**
+     * @param array<string, mixed>               $additionalVariables
+     * @param string|non-empty-list<string>|null $validator
+     */
+    protected function askForAdditionalVariable(
+        Config\Initialization\InitializationRequest $request,
+        string $label,
+        string $additionalVariable,
+        array &$additionalVariables,
+        mixed $default = null,
+        string|array $validator = null,
+    ): void {
+        $additionalValue = $this->questionHelper->ask(
+            $this->getInput($request),
+            $this->output,
+            $this->createQuestion($label, $default, validator: $validator),
+        );
+
+        if (null !== $additionalValue) {
+            $additionalVariables[$additionalVariable] = $additionalValue;
+        }
+    }
+
+    protected function getInput(Config\Initialization\InitializationRequest $request): SymfonyConsole\Input\InputInterface
+    {
+        return $request->getInput()
+            ?? throw new SymfonyConsole\Exception\RuntimeException('Input cannot be determined.', 1663088092);
+    }
+
+    /**
+     * @param string|non-empty-list<string> $type
+     *
+     * @throws Exception\UnsupportedTypeException
+     */
+    protected function createValidator(string|array $type): Console\Input\Validator\ValidatorInterface
+    {
+        if (is_array($type)) {
+            return $this->validatorFactory->getForAll($type);
+        }
+
+        return $this->validatorFactory->get($type);
+    }
+}

--- a/src/Config/Initialization/Step/ConfigFileStep.php
+++ b/src/Config/Initialization/Step/ConfigFileStep.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Helper;
+use Symfony\Component\Console;
+
+use function array_key_last;
+use function sprintf;
+
+/**
+ * ConfigFileStep.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class ConfigFileStep extends BaseStep implements InteractiveStepInterface
+{
+    public function __construct(
+        private readonly Config\ConfigFacade $configFacade,
+        private readonly Config\Parser\Parser $configParser,
+    ) {
+        parent::__construct();
+    }
+
+    public function getInputOptions(): array
+    {
+        return [
+            new Console\Input\InputOption(
+                'definition-id',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'ID of the asset definition to be added to the asset configuration file',
+                0,
+            ),
+        ];
+    }
+
+    public function execute(Config\Initialization\InitializationRequest $request): bool
+    {
+        $input = $this->getInput($request);
+
+        // Load config file
+        $configFile = $request->getConfigFile();
+        $config = $this->loadConfig($configFile);
+
+        // Early return if given config file does not exist yet
+        if (null === $config) {
+            $request->setConfig(new Config\Config([], $configFile));
+            $request->setOption('definition-id', 0);
+
+            return true;
+        }
+
+        // Fetch latest asset definition ID
+        $upperDefinitionId = (int) array_key_last($config['frontend-assets']);
+
+        // Early return if given definition id is valid
+        if ((int) $request->getOption('definition-id') > $upperDefinitionId) {
+            $request->setConfig($config);
+            $request->setOption('definition-id', $upperDefinitionId + 1);
+
+            return true;
+        }
+
+        // Early return if existing config file should be extended
+        if ($this->shouldExtendConfig($request)) {
+            $request->setConfig($config);
+            $request->setOption('definition-id', $upperDefinitionId + 1);
+
+            $this->output->writeln([
+                sprintf('Alright, the config file <info>%s</info> will be extended by a new asset definition.', $configFile),
+            ]);
+
+            return true;
+        }
+
+        // Use another config file
+        $configFile = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            new Console\Question\Question('<info>Path to the new config file</info>: '),
+        );
+        $request->setConfigFile(Helper\FilesystemHelper::resolveRelativePath($configFile, true));
+        $request->setConfig(new Config\Config([], $request->getConfigFile()));
+        $request->setOption('definition-id', 0);
+
+        $this->output->writeln([
+            sprintf('Alright, the config file <info>%s</info> will be used for the new asset definition.', $request->getConfigFile()),
+        ]);
+
+        return true;
+    }
+
+    private function shouldExtendConfig(Config\Initialization\InitializationRequest $request): bool
+    {
+        $configFile = $request->getConfigFile();
+
+        $this->output->writeln([
+            '',
+            sprintf('You have configured the file <info>%s</info> for your Frontend assets.', $configFile),
+            sprintf('A file with the name <info>%s</info> already exists.', $configFile),
+            'You can <comment>add a new asset definition</comment> to the existing config file or <comment>create a new config file</comment>.',
+            '',
+        ]);
+
+        return $this->askBooleanQuestion($request, sprintf('Add a new asset definition to %s?', $configFile));
+    }
+
+    private function loadConfig(string $configFile): ?Config\Config
+    {
+        try {
+            $config = $this->configFacade->load($configFile);
+        } catch (Exception\FilesystemFailureException) {
+            return null;
+        }
+
+        $instructions = new Config\Parser\ParserInstructions($config);
+        $instructions->processValues(false);
+
+        return $this->configParser->parse($instructions);
+    }
+}

--- a/src/Config/Initialization/Step/HandlerConfigStep.php
+++ b/src/Config/Initialization/Step/HandlerConfigStep.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Handler;
+use Symfony\Component\Console;
+use Symfony\Component\DependencyInjection;
+
+/**
+ * HandlerConfigStep.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class HandlerConfigStep extends BaseStep implements InteractiveStepInterface
+{
+    public function __construct(
+        private readonly DependencyInjection\ServiceLocator $handlers,
+    ) {
+        parent::__construct();
+    }
+
+    public function getInputOptions(): array
+    {
+        return [
+            new Console\Input\InputOption(
+                'handler-type',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Type of the asset handler, resolves to a supported asset handler',
+                Handler\AssetHandler::getName(),
+            ),
+        ];
+    }
+
+    public function execute(Config\Initialization\InitializationRequest $request): bool
+    {
+        $input = $this->getInput($request);
+        $io = new Console\Style\SymfonyStyle($input, $this->output);
+
+        $io->title('Handler');
+
+        // Ask for handler type
+        $handlerType = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createChoiceQuestion(
+                'Type',
+                $this->handlers->getProvidedServices(),
+                $request->getOption('handler-type'),
+            ),
+        );
+        $request->setOption('handler-type', $handlerType);
+
+        // Build handler
+        if (null !== $handlerType) {
+            $this->buildHandler($request, (string) $handlerType);
+        }
+
+        return true;
+    }
+
+    private function buildHandler(Config\Initialization\InitializationRequest $request, string $handlerType): void
+    {
+        $config = $request->getConfig();
+        $definitionId = (int) $request->getOption('definition-id');
+
+        $config['frontend-assets'][$definitionId]['handler'] = $handlerType;
+    }
+}

--- a/src/Config/Initialization/Step/InteractiveStepInterface.php
+++ b/src/Config/Initialization/Step/InteractiveStepInterface.php
@@ -21,30 +21,20 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
+namespace CPSIT\FrontendAssetHandler\Config\Initialization\Step;
 
-use Webmozart\Assert;
-
-use function json_decode;
+use Symfony\Component\Console;
 
 /**
- * JsonValidator.
+ * InteractiveStepInterface.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class JsonValidator implements ValidatorInterface
+interface InteractiveStepInterface extends StepInterface
 {
-    public function validate(mixed $value): mixed
-    {
-        if (null !== $value) {
-            Assert\Assert::string($value);
-            Assert\Assert::notNull($json = json_decode((string) $value), 'JSON is invalid.');
-            Assert\Assert::object($json);
-        }
-
-        return $value;
-    }
+    /**
+     * @return list<Console\Input\InputOption>
+     */
+    public function getInputOptions(): array;
 }

--- a/src/Config/Initialization/Step/SourceConfigStep.php
+++ b/src/Config/Initialization/Step/SourceConfigStep.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Provider;
+use Symfony\Component\Console;
+use Symfony\Component\DependencyInjection;
+
+use function array_replace_recursive;
+use function is_array;
+use function is_string;
+use function json_decode;
+
+/**
+ * SourceConfigStep.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class SourceConfigStep extends BaseStep implements InteractiveStepInterface
+{
+    public function __construct(
+        private readonly DependencyInjection\ServiceLocator $providers,
+    ) {
+        parent::__construct();
+    }
+
+    public function getInputOptions(): array
+    {
+        return [
+            new Console\Input\InputOption(
+                'source-type',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Type of the asset source, resolves to a supported asset provider',
+                Provider\HttpFileProvider::getName(),
+            ),
+            new Console\Input\InputOption(
+                'source-url',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'URL to locate the asset source files, can contain placeholders in the form {<config key>}',
+            ),
+            new Console\Input\InputOption(
+                'source-revision-url',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'URL to locate the revision of asset source files, can contain placeholders in the form {<config key>}',
+            ),
+            new Console\Input\InputOption(
+                'source-config-extra',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Additional configuration for the asset source definition, should be a JSON-encoded string',
+            ),
+        ];
+    }
+
+    public function execute(Config\Initialization\InitializationRequest $request): bool
+    {
+        $input = $this->getInput($request);
+        $io = new Console\Style\SymfonyStyle($input, $this->output);
+
+        $io->title('Source');
+
+        // Initialize additional variables
+        $additionalVariables = [];
+
+        // Source type
+        $sourceType = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createChoiceQuestion(
+                'Type',
+                $this->providers->getProvidedServices(),
+                $request->getOption('source-type'),
+            ),
+        );
+        $request->setOption('source-type', $sourceType);
+
+        // Source url
+        $sourceUrl = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createQuestion(
+                'URL',
+                $request->getOption('source-url'),
+                validator: ['notEmpty', 'url'],
+            ),
+        );
+        $request->setOption('source-url', $sourceUrl);
+
+        // Source url placeholders
+        $this->askForPlaceholderVariables(
+            $request,
+            $sourceUrl,
+            'URL placeholder "%s" (optional)',
+            $additionalVariables,
+        );
+
+        // Source revision url
+        $sourceRevisionUrl = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createQuestion(
+                'Revision URL',
+                $request->getOption('source-revision-url'),
+                validator: 'url',
+            ),
+        );
+        $request->setOption('source-revision-url', $sourceRevisionUrl);
+
+        // Source revision url placeholders
+        $this->askForPlaceholderVariables(
+            $request,
+            $sourceRevisionUrl,
+            'Revision URL placeholder "%s" (optional)',
+            $additionalVariables,
+        );
+
+        // Source config extra
+        $sourceConfigExtra = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createQuestion(
+                'Additional config',
+                $request->getOption('source-config-extra'),
+                validator: 'json',
+            ),
+        );
+
+        if (is_string($sourceConfigExtra)) {
+            $additionalVariables = array_replace_recursive(
+                $additionalVariables,
+                json_decode($sourceConfigExtra, true, flags: JSON_THROW_ON_ERROR),
+            );
+        }
+
+        $request->setOption('source-config-extra', $additionalVariables);
+
+        // Build source
+        $this->buildSource($request);
+
+        return true;
+    }
+
+    private function buildSource(Config\Initialization\InitializationRequest $request): void
+    {
+        $config = $request->getConfig();
+        $definitionId = (int) $request->getOption('definition-id');
+
+        // Define default source configuration
+        $sourceConfig = [
+            'type' => $request->getOption('source-type'),
+            'url' => $request->getOption('source-url'),
+        ];
+
+        // Add revision URL
+        if (is_string($request->getOption('source-revision-url'))) {
+            $sourceConfig['revision-url'] = $request->getOption('source-revision-url');
+        }
+
+        // Merge additional source configuration
+        $sourceConfigExtra = $request->getOption('source-config-extra');
+        if (is_array($sourceConfigExtra)) {
+            $sourceConfig = array_replace_recursive($sourceConfig, $sourceConfigExtra);
+        }
+
+        // Apply source
+        $config['frontend-assets'][$definitionId]['source'] = $sourceConfig;
+    }
+}

--- a/src/Config/Initialization/Step/StepInterface.php
+++ b/src/Config/Initialization/Step/StepInterface.php
@@ -21,30 +21,19 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
+namespace CPSIT\FrontendAssetHandler\Config\Initialization\Step;
 
-use Webmozart\Assert;
-
-use function json_decode;
+use CPSIT\FrontendAssetHandler\Config;
 
 /**
- * JsonValidator.
+ * StepInterface.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  *
  * @internal
  */
-final class JsonValidator implements ValidatorInterface
+interface StepInterface
 {
-    public function validate(mixed $value): mixed
-    {
-        if (null !== $value) {
-            Assert\Assert::string($value);
-            Assert\Assert::notNull($json = json_decode((string) $value), 'JSON is invalid.');
-            Assert\Assert::object($json);
-        }
-
-        return $value;
-    }
+    public function execute(Config\Initialization\InitializationRequest $request): bool;
 }

--- a/src/Config/Initialization/Step/TargetConfigStep.php
+++ b/src/Config/Initialization/Step/TargetConfigStep.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Asset;
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Processor;
+use Symfony\Component\Console;
+use Symfony\Component\DependencyInjection;
+
+use function array_replace_recursive;
+use function is_array;
+use function is_string;
+
+/**
+ * TargetConfigStep.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class TargetConfigStep extends BaseStep implements InteractiveStepInterface
+{
+    public function __construct(
+        private readonly DependencyInjection\ServiceLocator $processors,
+    ) {
+        parent::__construct();
+    }
+
+    public function getInputOptions(): array
+    {
+        return [
+            new Console\Input\InputOption(
+                'target-type',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Type of the asset target, resolves to a supported asset processor',
+                Processor\FileArchiveProcessor::getName(),
+            ),
+            new Console\Input\InputOption(
+                'target-path',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Path where to extract fetched assets, can be either absolute or relative to the config file',
+            ),
+            new Console\Input\InputOption(
+                'target-revision-file',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Filename of the asset target\'s revision file',
+                Asset\Definition\Target::DEFAULT_REVISION_FILE,
+            ),
+            new Console\Input\InputOption(
+                'target-config-extra',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Additional configuration for the asset target definition, should be a JSON-encoded string',
+            ),
+        ];
+    }
+
+    public function execute(Config\Initialization\InitializationRequest $request): bool
+    {
+        $input = $this->getInput($request);
+        $io = new Console\Style\SymfonyStyle($input, $this->output);
+
+        $io->title('Target');
+
+        // Initialize additional variables
+        $additionalVariables = [];
+
+        // Target type
+        $targetType = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createChoiceQuestion(
+                'Type',
+                $this->processors->getProvidedServices(),
+                $request->getOption('target-type'),
+            ),
+        );
+        $request->setOption('target-type', $targetType);
+
+        // Target path
+        $targetPath = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createQuestion(
+                'Path',
+                $request->getOption('target-path'),
+                validator: 'notEmpty',
+            ),
+        );
+        $request->setOption('target-path', $targetPath);
+
+        // Additional variables for FileArchiveProcessor only)
+        if (Processor\FileArchiveProcessor::getName() === $targetType) {
+            $this->askForAdditionalVariable(
+                $request,
+                'Base archive path',
+                'base',
+                $additionalVariables,
+                '',
+            );
+        }
+
+        // Target revision file
+        $targetRevisionFile = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createQuestion(
+                'Revision file',
+                $request->getOption('target-revision-file'),
+                validator: 'notEmpty',
+            ),
+        );
+        $request->setOption('target-revision-file', $targetRevisionFile);
+
+        // Target config extra
+        $targetConfigExtra = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createQuestion(
+                'Additional config',
+                $request->getOption('target-config-extra'),
+                validator: 'json',
+            ),
+        );
+
+        if (is_string($targetConfigExtra)) {
+            $additionalVariables = array_replace_recursive(
+                $additionalVariables,
+                json_decode($targetConfigExtra, true, flags: JSON_THROW_ON_ERROR),
+            );
+        }
+
+        $request->setOption('target-config-extra', $additionalVariables);
+
+        // Build target
+        $this->buildTarget($request);
+
+        return true;
+    }
+
+    private function buildTarget(Config\Initialization\InitializationRequest $request): void
+    {
+        $config = $request->getConfig();
+        $definitionId = (int) $request->getOption('definition-id');
+
+        // Define default target configuration
+        $targetConfig = [
+            'type' => $request->getOption('target-type'),
+            'path' => $request->getOption('target-path'),
+            'revision-file' => $request->getOption('target-revision-file'),
+        ];
+
+        // Merge additional target configuration
+        $targetConfigExtra = $request->getOption('target-config-extra');
+        if (is_array($targetConfigExtra)) {
+            $targetConfig = array_replace_recursive($targetConfig, $targetConfigExtra);
+        }
+
+        // Apply target
+        $config['frontend-assets'][$definitionId]['target'] = $targetConfig;
+    }
+}

--- a/src/Config/Initialization/Step/VcsConfigStep.php
+++ b/src/Config/Initialization/Step/VcsConfigStep.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Vcs;
+use Symfony\Component\Console;
+use Symfony\Component\DependencyInjection;
+
+use function array_replace_recursive;
+use function is_array;
+use function is_string;
+
+/**
+ * VcsConfigStep.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class VcsConfigStep extends BaseStep implements InteractiveStepInterface
+{
+    public function __construct(
+        private readonly DependencyInjection\ServiceLocator $vcsProviders,
+    ) {
+        parent::__construct();
+    }
+
+    public function getInputOptions(): array
+    {
+        return [
+            new Console\Input\InputOption(
+                'vcs-type',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Type of the asset\'s VCS, resolves to a supported VCS provider',
+            ),
+            new Console\Input\InputOption(
+                'vcs-config-extra',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Additional configuration for the asset VCS definition, should be a JSON-encoded string',
+            ),
+        ];
+    }
+
+    public function execute(Config\Initialization\InitializationRequest $request): bool
+    {
+        $input = $this->getInput($request);
+        $io = new Console\Style\SymfonyStyle($input, $this->output);
+
+        $io->title('VCS');
+
+        // Early return if VCS should not be configured
+        if (!$this->shouldConfigureVcs($request)) {
+            return true;
+        }
+
+        // Initialize additional variables
+        $additionalVariables = [];
+
+        // VCS type
+        $vcsType = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createChoiceQuestion(
+                'Type',
+                $this->vcsProviders->getProvidedServices(),
+                $request->getOption('vcs-type'),
+            ),
+        );
+        $request->setOption('vcs-type', $vcsType);
+
+        // Additional variables for GitlabVcsProvider only
+        if (Vcs\GitlabVcsProvider::getName() === $vcsType) {
+            $this->askForAdditionalVariable(
+                $request,
+                'Base URL',
+                'base-url',
+                $additionalVariables,
+                'https://gitlab.com',
+                ['notEmpty', 'url'],
+            );
+
+            $this->askForAdditionalVariable(
+                $request,
+                'Access token',
+                'access-token',
+                $additionalVariables,
+                validator: 'notEmpty',
+            );
+
+            $this->askForAdditionalVariable(
+                $request,
+                'Project ID',
+                'project-id',
+                $additionalVariables,
+                validator: 'integer',
+            );
+        }
+
+        // VCS config extra
+        $vcsConfigExtra = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createQuestion(
+                'Additional config',
+                $request->getOption('vcs-config-extra'),
+                validator: 'json',
+            ),
+        );
+
+        if (is_string($vcsConfigExtra)) {
+            $additionalVariables = array_replace_recursive(
+                $additionalVariables,
+                json_decode($vcsConfigExtra, true, flags: JSON_THROW_ON_ERROR),
+            );
+        }
+
+        $request->setOption('vcs-config-extra', $additionalVariables);
+
+        // Build VCS
+        $this->buildVcs($request);
+
+        return true;
+    }
+
+    private function buildVcs(Config\Initialization\InitializationRequest $request): void
+    {
+        $config = $request->getConfig();
+        $definitionId = (int) $request->getOption('definition-id');
+
+        // Define default VCS configuration
+        $vcsConfig = [
+            'type' => $request->getOption('vcs-type'),
+        ];
+
+        // Merge additional VCS configuration
+        $vcsConfigExtra = $request->getOption('vcs-config-extra');
+        if (is_array($vcsConfigExtra)) {
+            $vcsConfig = array_replace_recursive($vcsConfig, $vcsConfigExtra);
+        }
+
+        // Apply VCS
+        $config['frontend-assets'][$definitionId]['vcs'] = $vcsConfig;
+    }
+
+    private function shouldConfigureVcs(Config\Initialization\InitializationRequest $request): bool
+    {
+        if (null !== $request->getOption('vcs-type')) {
+            return true;
+        }
+
+        $this->output->writeln('The following VCS configuration is optional.');
+
+        return $this->askBooleanQuestion($request, 'Add VCS configuration?');
+    }
+}

--- a/src/Console/Input/Validator/ChainedValidator.php
+++ b/src/Console/Input/Validator/ChainedValidator.php
@@ -23,26 +23,28 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
 
-use Webmozart\Assert;
-
-use function json_decode;
-
 /**
- * JsonValidator.
+ * ChainedValidator.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  *
  * @internal
  */
-final class JsonValidator implements ValidatorInterface
+final class ChainedValidator implements ValidatorInterface
 {
+    /**
+     * @param non-empty-list<ValidatorInterface> $validators
+     */
+    public function __construct(
+        private readonly array $validators,
+    ) {
+    }
+
     public function validate(mixed $value): mixed
     {
-        if (null !== $value) {
-            Assert\Assert::string($value);
-            Assert\Assert::notNull($json = json_decode((string) $value), 'JSON is invalid.');
-            Assert\Assert::object($json);
+        foreach ($this->validators as $validator) {
+            $value = $validator->validate($value);
         }
 
         return $value;

--- a/src/Console/Input/Validator/IntegerValidator.php
+++ b/src/Console/Input/Validator/IntegerValidator.php
@@ -25,26 +25,30 @@ namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
 
 use Webmozart\Assert;
 
-use function json_decode;
+use function is_int;
 
 /**
- * JsonValidator.
+ * IntegerValidator.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  *
  * @internal
  */
-final class JsonValidator implements ValidatorInterface
+final class IntegerValidator implements ValidatorInterface
 {
-    public function validate(mixed $value): mixed
+    public function validate(mixed $value): ?int
     {
-        if (null !== $value) {
-            Assert\Assert::string($value);
-            Assert\Assert::notNull($json = json_decode((string) $value), 'JSON is invalid.');
-            Assert\Assert::object($json);
+        if (null === $value) {
+            return null;
         }
 
-        return $value;
+        if (is_int($value)) {
+            return $value;
+        }
+
+        Assert\Assert::numeric($value);
+
+        return (int) $value;
     }
 }

--- a/src/Console/Input/Validator/NotEmptyValidator.php
+++ b/src/Console/Input/Validator/NotEmptyValidator.php
@@ -30,10 +30,12 @@ use Webmozart\Assert;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @internal
  */
 final class NotEmptyValidator implements ValidatorInterface
 {
-    public static function validate(mixed $value): mixed
+    public function validate(mixed $value): mixed
     {
         Assert\Assert::notEmpty($value);
 

--- a/src/Console/Input/Validator/UrlValidator.php
+++ b/src/Console/Input/Validator/UrlValidator.php
@@ -32,11 +32,17 @@ use function filter_var;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @internal
  */
 final class UrlValidator implements ValidatorInterface
 {
-    public static function validate(mixed $value): string
+    public function validate(mixed $value): ?string
     {
+        if (null === $value) {
+            return null;
+        }
+
         Assert\Assert::stringNotEmpty($value);
 
         // Allow placeholders in URLs. Those will be replaced later by string interpolation.

--- a/src/Console/Input/Validator/ValidatorInterface.php
+++ b/src/Console/Input/Validator/ValidatorInterface.php
@@ -28,8 +28,10 @@ namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @internal
  */
 interface ValidatorInterface
 {
-    public static function validate(mixed $value): mixed;
+    public function validate(mixed $value): mixed;
 }

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -21,30 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
+namespace CPSIT\FrontendAssetHandler\Exception;
 
-use Webmozart\Assert;
-
-use function json_decode;
+use function sprintf;
 
 /**
- * JsonValidator.
+ * UnexpectedValueException.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class JsonValidator implements ValidatorInterface
+final class UnexpectedValueException extends \UnexpectedValueException
 {
-    public function validate(mixed $value): mixed
+    public static function forInvalidString(string $string): self
     {
-        if (null !== $value) {
-            Assert\Assert::string($value);
-            Assert\Assert::notNull($json = json_decode((string) $value), 'JSON is invalid.');
-            Assert\Assert::object($json);
-        }
-
-        return $value;
+        return new self(
+            sprintf('The string "%s" is invalid and cannot be processed.', $string),
+            1663166818,
+        );
     }
 }

--- a/src/Helper/StringHelper.php
+++ b/src/Helper/StringHelper.php
@@ -39,6 +39,8 @@ use function rawurlencode;
  */
 final class StringHelper
 {
+    private const PLACEHOLDER_REGEX = '/{([\\w-]+)}/';
+
     /**
      * @see https://gist.github.com/liunian/9338301#gistcomment-3114711
      */
@@ -71,11 +73,25 @@ final class StringHelper
 
         $result = strtr($string, $normalizedPairs);
 
-        if (1 === preg_match('/{([\w-]+)}/', $result, $matches)) {
-            throw Exception\MissingConfigurationException::forKey($matches[1]);
+        if ($matches = self::extractPlaceholders($result)) {
+            throw Exception\MissingConfigurationException::forKey(reset($matches));
         }
 
         return $result;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function extractPlaceholders(string $string): array
+    {
+        if (false === preg_match_all(self::PLACEHOLDER_REGEX, $string, $matches)) {
+            // @codeCoverageIgnoreStart
+            throw Exception\UnexpectedValueException::forInvalidString($string);
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $matches[1];
     }
 
     public static function urlEncode(mixed $value): mixed

--- a/src/Processor/FileArchiveProcessor.php
+++ b/src/Processor/FileArchiveProcessor.php
@@ -57,7 +57,7 @@ final class FileArchiveProcessor implements ProcessorInterface, ChattyInterface
     ];
 
     private const DEFAULT_CONFIGURATION = [
-        'base' => 'dist/',
+        'base' => '',
     ];
 
     public function __construct(

--- a/tests/Unit/Command/InitConfigCommandTest.php
+++ b/tests/Unit/Command/InitConfigCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Command;
+
+use CPSIT\FrontendAssetHandler\Command;
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Tests;
+use Symfony\Component\Console;
+
+use function json_encode;
+use function sprintf;
+
+/**
+ * InitConfigCommandTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class InitConfigCommandTest extends Tests\Unit\CommandTesterAwareTestCase
+{
+    private Tests\Unit\Fixtures\Classes\DummyStep $firstStep;
+    private Tests\Unit\Fixtures\Classes\DummyInteractiveStep $secondStep;
+    private Config\Config $config;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->firstStep = $this->container->get(Tests\Unit\Fixtures\Classes\DummyStep::class);
+        $this->secondStep = $this->container->get(Tests\Unit\Fixtures\Classes\DummyInteractiveStep::class);
+
+        self::assertNotNull($this->configFile);
+
+        $this->config = $this->container->get(Config\ConfigFacade::class)->load($this->configFile);
+    }
+
+    /**
+     * @test
+     */
+    public function executeAddsOptionsFromInteractiveStepsToInputDefinition(): void
+    {
+        $this->secondStep->expectedConfig = $this->config;
+
+        $exitCode = $this->commandTester->execute([
+            '--config' => $this->config->getFilePath(),
+            '--foo' => 'foo',
+            '--baz' => 'baz',
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame(
+            $this->config['frontend-assets'][0]['request-options'],
+            [
+                'config' => $this->config->getFilePath(),
+                'foo' => 'foo',
+                'baz' => 'baz',
+            ],
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function executeThrowsExceptionIfStepFails(): void
+    {
+        $this->firstStep->expectedReturn = false;
+
+        $exitCode = $this->commandTester->execute(['--config' => 'foo']);
+        $output = $this->commandTester->getDisplay();
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString(
+            sprintf('Action "%s" failed', $this->firstStep::class),
+            $output,
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function executeAppliesOutputToInteractiveSteps(): void
+    {
+        self::assertInstanceOf(Console\Output\NullOutput::class, $this->secondStep->getOutput()->getOutput());
+
+        $this->secondStep->expectedConfig = $this->config;
+
+        $exitCode = $this->commandTester->execute(['--config' => $this->configFile]);
+
+        self::assertSame(0, $exitCode);
+        self::assertNotInstanceOf(Console\Output\NullOutput::class, $this->secondStep->getOutput()->getOutput());
+    }
+
+    /**
+     * @test
+     */
+    public function executeThrowsExceptionIfInitializedConfigIsInvalid(): void
+    {
+        $this->expectException(Exception\InvalidConfigurationException::class);
+        $this->expectExceptionCode(1643113965);
+
+        $this->commandTester->execute(['--config' => 'foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function executeWritesInitializedConfig(): void
+    {
+        unset($this->config['frontend-assets'][1]);
+
+        $this->secondStep->expectedConfig = $this->config;
+
+        $exitCode = $this->commandTester->execute(['--config' => $this->config->getFilePath()]);
+        $output = $this->commandTester->getDisplay();
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('Asset configuration was successfully written', $output);
+        self::assertJsonStringEqualsJsonFile($this->config->getFilePath(), json_encode($this->config) ?: '');
+    }
+
+    protected static function getCoveredCommand(): string
+    {
+        return Command\InitConfigCommand::class;
+    }
+}

--- a/tests/Unit/Config/Initialization/InitializationRequestTest.php
+++ b/tests/Unit/Config/Initialization/InitializationRequestTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Config\Initialization;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Exception;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console;
+
+/**
+ * InitializationRequestTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class InitializationRequestTest extends TestCase
+{
+    private Console\Input\ArrayInput $input;
+    private Config\Initialization\InitializationRequest $subject;
+
+    protected function setUp(): void
+    {
+        $this->input = new Console\Input\ArrayInput([], new Console\Input\InputDefinition([
+            new Console\Input\InputOption('config', mode: Console\Input\InputOption::VALUE_REQUIRED),
+            new Console\Input\InputOption('dummy-option', mode: Console\Input\InputOption::VALUE_OPTIONAL),
+        ]));
+        $this->subject = new Config\Initialization\InitializationRequest('foo', ['foo' => 'baz'], $this->input);
+    }
+
+    /**
+     * @test
+     */
+    public function fromCommandInputThrowsExceptionIfConfigFileIsMissing(): void
+    {
+        $this->expectExceptionObject(Exception\MissingConfigurationException::create());
+
+        Config\Initialization\InitializationRequest::fromCommandInput($this->input);
+    }
+
+    /**
+     * @test
+     */
+    public function fromCommandInputReturnsInitializationRequestBuiltFromGivenInput(): void
+    {
+        $this->input->setOption('config', 'foo');
+        $this->input->setOption('dummy-option', 'baz');
+
+        $actual = Config\Initialization\InitializationRequest::fromCommandInput($this->input);
+
+        self::assertSame([], $actual->getConfig()->asArray());
+        self::assertSame('foo', $actual->getConfigFile());
+        self::assertSame(
+            [
+                'config' => 'foo',
+                'dummy-option' => 'baz',
+            ],
+            $actual->getOptions(),
+        );
+        self::assertSame($this->input, $actual->getInput());
+    }
+
+    /**
+     * @test
+     */
+    public function getConfigCreatesNewConfigIfItDoesNotExistYet(): void
+    {
+        $config = $this->subject->getConfig();
+
+        self::assertInstanceOf(Config\Config::class, $config);
+        self::assertSame('foo', $config->getFilePath());
+        self::assertSame($config, $this->subject->getConfig());
+    }
+
+    /**
+     * @test
+     */
+    public function setConfigAppliesConfig(): void
+    {
+        $config = new Config\Config(['foo' => 'baz'], 'foo');
+
+        $this->subject->setConfig($config);
+
+        self::assertSame($config, $this->subject->getConfig());
+    }
+
+    /**
+     * @test
+     */
+    public function setConfigFileAppliesConfigFile(): void
+    {
+        self::assertSame('foo', $this->subject->getConfigFile());
+
+        $this->subject->setConfigFile('baz');
+
+        self::assertSame('baz', $this->subject->getConfigFile());
+    }
+
+    /**
+     * @test
+     */
+    public function getOptionThrowsExceptionIfOptionDoesNotExist(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionCode(1663086743);
+        $this->expectExceptionMessage('The initialization option "baz" does not exist.');
+
+        $this->subject->getOption('baz');
+    }
+
+    /**
+     * @test
+     */
+    public function setOptionAppliesOption(): void
+    {
+        $this->subject->setOption('baz', 'foo');
+
+        self::assertSame('foo', $this->subject->getOption('baz'));
+    }
+}

--- a/tests/Unit/Config/Initialization/Step/ConfigFileStepTest.php
+++ b/tests/Unit/Config/Initialization/Step/ConfigFileStepTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Tests;
+use Generator;
+use Symfony\Component\Console;
+
+use function dirname;
+use function sprintf;
+
+/**
+ * ConfigFileStepTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class ConfigFileStepTest extends Tests\Unit\ContainerAwareTestCase
+{
+    use InitializationRequestTrait;
+    use Tests\Unit\InteractiveConsoleInputTrait;
+
+    private Console\Output\BufferedOutput $output;
+    private Config\Initialization\Step\ConfigFileStep $subject;
+    private Config\Initialization\InitializationRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = $this->container->get(Config\Initialization\Step\ConfigFileStep::class);
+        $this->subject->setOutput($this->output);
+        $this->request = $this->createRequest($this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function executeThrowsExceptionIfGivenConfigFileIsInvalid(): void
+    {
+        $this->request->setConfigFile(dirname(__DIR__, 3).'/Fixtures/JsonFiles/invalid-assets.json');
+
+        $this->expectException(Exception\InvalidConfigurationException::class);
+        $this->expectExceptionCode(1643113965);
+
+        $this->subject->execute($this->request);
+    }
+
+    /**
+     * @test
+     */
+    public function executeCreatesNewConfigIfGivenConfigFileDoesNotExist(): void
+    {
+        $configFile = dirname(__DIR__, 3).'/Fixtures/JsonFiles/foo.json';
+
+        $this->request->setConfigFile($configFile);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame($configFile, $this->request->getConfig()->getFilePath());
+        self::assertSame(0, $this->request->getOption('definition-id'));
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider executeUsesTheExistingConfigFileWithANewDefinitionIdDataProvider
+     */
+    public function executeUsesTheExistingConfigFileWithANewDefinitionId(int $definitionId, int $expected): void
+    {
+        $this->request->setOption('definition-id', $definitionId);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame($expected, $this->request->getOption('definition-id'));
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksAndExtendsGivenConfigFile(): void
+    {
+        $configFile = $this->request->getConfigFile();
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes'], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame($configFile, $this->request->getConfigFile());
+        self::assertSame(2, $this->request->getOption('definition-id'));
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString(
+            sprintf('You have configured the file %s for your Frontend assets.', $configFile),
+            $output,
+        );
+        self::assertStringContainsString(
+            sprintf('A file with the name %s already exists.', $configFile),
+            $output,
+        );
+        self::assertStringContainsString(
+            'You can add a new asset definition to the existing config file or create a new config file.',
+            $output,
+        );
+        self::assertStringContainsString(
+            sprintf('Add a new asset definition to %s?', $configFile),
+            $output,
+        );
+        self::assertStringContainsString(
+            sprintf('Alright, the config file %s will be extended by a new asset definition.', $configFile),
+            $output,
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksAndUsesAnotherConfigFileIfExistingConfigFileShouldNotBeExtended(): void
+    {
+        $configFile = '/tmp/foo.json';
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['no', $configFile], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame($configFile, $this->request->getConfigFile());
+        self::assertSame(0, $this->request->getOption('definition-id'));
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString(
+            sprintf('Alright, the config file %s will be used for the new asset definition.', $configFile),
+            $output,
+        );
+    }
+
+    /**
+     * @return Generator<string, array{int, int}>
+     */
+    public function executeUsesTheExistingConfigFileWithANewDefinitionIdDataProvider(): Generator
+    {
+        yield 'lowest possible new definition ID' => [2, 2];
+        yield 'any higher new definition ID' => [42, 2];
+    }
+}

--- a/tests/Unit/Config/Initialization/Step/HandlerConfigStepTest.php
+++ b/tests/Unit/Config/Initialization/Step/HandlerConfigStepTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Handler\AssetHandler;
+use CPSIT\FrontendAssetHandler\Tests;
+use Symfony\Component\Console;
+
+/**
+ * HandlerConfigStepTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class HandlerConfigStepTest extends Tests\Unit\ContainerAwareTestCase
+{
+    use InitializationRequestTrait;
+    use Tests\Unit\InteractiveConsoleInputTrait;
+
+    private Console\Output\BufferedOutput $output;
+    private Config\Initialization\Step\HandlerConfigStep $subject;
+    private Config\Initialization\InitializationRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = $this->container->get(Config\Initialization\Step\HandlerConfigStep::class);
+        $this->subject->setOutput($this->output);
+        $this->request = $this->createRequest($this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function executeUsesDefaultHandlerTypeIfUserEntersNothing(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs([''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            AssetHandler::getName(),
+            $this->request->getConfig()['frontend-assets'][0]['handler'],
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowsErrorIfGivenHandlerTypeIsNotSupported(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['foo'], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Value "foo" is invalid', $output);
+        self::assertSame(
+            AssetHandler::getName(),
+            $this->request->getConfig()['frontend-assets'][0]['handler'],
+        );
+    }
+}

--- a/tests/Unit/Config/Initialization/Step/InitializationRequestTrait.php
+++ b/tests/Unit/Config/Initialization/Step/InitializationRequestTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use Symfony\Component\Console;
+
+use function array_map;
+use function dirname;
+use function in_array;
+
+/**
+ * InitializationRequestTrait.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+trait InitializationRequestTrait
+{
+    private function createRequest(
+        Config\Initialization\Step\InteractiveStepInterface $subject,
+        string $configFile = null,
+        int $definitionId = 0,
+    ): Config\Initialization\InitializationRequest {
+        $definition = $subject->getInputOptions();
+
+        $definedOptions = array_map(
+            fn (Console\Input\InputOption $inputOption): string => $inputOption->getName(),
+            $definition,
+        );
+
+        if (!in_array('config', $definedOptions, true)) {
+            $definition[] = new Console\Input\InputOption('config', mode: Console\Input\InputOption::VALUE_REQUIRED);
+        }
+        if (!in_array('definition-id', $definedOptions, true)) {
+            $definition[] = new Console\Input\InputOption('definition-id', mode: Console\Input\InputOption::VALUE_REQUIRED);
+        }
+
+        $configFile ??= dirname(__DIR__, 3).'/Fixtures/JsonFiles/assets.json';
+
+        return Config\Initialization\InitializationRequest::fromCommandInput(
+            new Console\Input\ArrayInput(
+                [
+                    '--config' => $configFile,
+                    '--definition-id' => $definitionId,
+                ],
+                new Console\Input\InputDefinition($definition),
+            ),
+        );
+    }
+}

--- a/tests/Unit/Config/Initialization/Step/SourceConfigStepTest.php
+++ b/tests/Unit/Config/Initialization/Step/SourceConfigStepTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Provider;
+use CPSIT\FrontendAssetHandler\Tests;
+use Symfony\Component\Console;
+
+/**
+ * SourceConfigStepTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class SourceConfigStepTest extends Tests\Unit\ContainerAwareTestCase
+{
+    use InitializationRequestTrait;
+    use Tests\Unit\InteractiveConsoleInputTrait;
+
+    private Console\Output\BufferedOutput $output;
+    private Config\Initialization\Step\SourceConfigStep $subject;
+    private Config\Initialization\InitializationRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = $this->container->get(Config\Initialization\Step\SourceConfigStep::class);
+        $this->subject->setOutput($this->output);
+        $this->request = $this->createRequest($this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function executeUsesDefaultSourceTypeIfUserEntersNothing(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['', 'https://www.example.com', '', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            Provider\HttpFileProvider::getName(),
+            $this->request->getConfig()['frontend-assets'][0]['source']['type'],
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowsErrorIfGivenSourceTypeIsNotSupported(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['foo', '', 'https://www.example.com', '', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            Provider\HttpFileProvider::getName(),
+            $this->request->getConfig()['frontend-assets'][0]['source']['type'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Value "foo" is invalid', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksForPlaceholdersInGivenSourceUrl(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['', 'https://www.example.com/{environment}/{foo}', 'foo', '', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'https://www.example.com/{environment}/{foo}',
+            $this->request->getConfig()['frontend-assets'][0]['source']['url'],
+        );
+        self::assertSame(
+            'foo',
+            $this->request->getConfig()['frontend-assets'][0]['source']['foo'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('URL placeholder "foo" (optional)', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksForPlaceholdersInGivenSourceRevisionUrl(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(
+            ['', 'https://www.example.com/', 'https://www.example.com/{revision-file}', 'revision.txt', ''],
+            $input,
+        );
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'https://www.example.com/{revision-file}',
+            $this->request->getConfig()['frontend-assets'][0]['source']['revision-url'],
+        );
+        self::assertSame(
+            'revision.txt',
+            $this->request->getConfig()['frontend-assets'][0]['source']['revision-file'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Revision URL placeholder "revision-file" (optional)', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowErrorIfGivenSourceConfigExtraIsNotValidJson(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(
+            ['', 'https://www.example.com/', '', 'foo', ''],
+            $input,
+        );
+
+        self::assertTrue($this->subject->execute($this->request));
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('JSON is invalid.', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeMergesSourceConfigExtraWithAdditionalVariables(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(
+            ['', 'https://www.example.com/{foo}', 'foo', 'https://www.example.com/{baz}', 'baz', '{"hello":"world"}'],
+            $input,
+        );
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'https://www.example.com/{foo}',
+            $this->request->getConfig()['frontend-assets'][0]['source']['url'],
+        );
+        self::assertSame(
+            'https://www.example.com/{baz}',
+            $this->request->getConfig()['frontend-assets'][0]['source']['revision-url'],
+        );
+        self::assertSame(
+            'foo',
+            $this->request->getConfig()['frontend-assets'][0]['source']['foo'],
+        );
+        self::assertSame(
+            'baz',
+            $this->request->getConfig()['frontend-assets'][0]['source']['baz'],
+        );
+        self::assertSame(
+            'world',
+            $this->request->getConfig()['frontend-assets'][0]['source']['hello'],
+        );
+    }
+}

--- a/tests/Unit/Config/Initialization/Step/TargetConfigStepTest.php
+++ b/tests/Unit/Config/Initialization/Step/TargetConfigStepTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Processor;
+use CPSIT\FrontendAssetHandler\Tests;
+use Symfony\Component\Console;
+
+/**
+ * TargetConfigStepTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class TargetConfigStepTest extends Tests\Unit\ContainerAwareTestCase
+{
+    use InitializationRequestTrait;
+    use Tests\Unit\InteractiveConsoleInputTrait;
+
+    private Console\Output\BufferedOutput $output;
+    private Config\Initialization\Step\TargetConfigStep $subject;
+    private Config\Initialization\InitializationRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = $this->container->get(Config\Initialization\Step\TargetConfigStep::class);
+        $this->subject->setOutput($this->output);
+        $this->request = $this->createRequest($this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function executeUsesDefaultTargetTypeIfUserEntersNothing(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['', 'foo', 'baz', '', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            Processor\FileArchiveProcessor::getName(),
+            $this->request->getConfig()['frontend-assets'][0]['target']['type'],
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowsErrorIfGivenTargetTypeIsNotSupported(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['foo', '', 'foo', 'baz', '', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            Processor\FileArchiveProcessor::getName(),
+            $this->request->getConfig()['frontend-assets'][0]['target']['type'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Value "foo" is invalid', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksForBaseArchivePathForTargetTypeArchive(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['', 'foo', 'baz', '', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'baz',
+            $this->request->getConfig()['frontend-assets'][0]['target']['base'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Base archive path', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeDoesNotAskForBaseArchivePathIfTargetTypeIsNotArchive(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs([Processor\ExistingAssetProcessor::getName(), 'foo', '', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertArrayNotHasKey('base', $this->request->getConfig()['frontend-assets'][0]['target']);
+
+        $output = $this->output->fetch();
+
+        self::assertStringNotContainsString('Base archive path', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowErrorIfGivenTargetConfigExtraIsNotValidJson(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['', 'foo', 'baz', '', 'foo', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('JSON is invalid.', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeMergesTargetConfigExtraWithAdditionalVariables(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['', 'foo', 'baz', '', '{"foo":"baz"}'], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'baz',
+            $this->request->getConfig()['frontend-assets'][0]['target']['base'],
+        );
+        self::assertSame(
+            'baz',
+            $this->request->getConfig()['frontend-assets'][0]['target']['foo'],
+        );
+    }
+}

--- a/tests/Unit/Config/Initialization/Step/VcsConfigStepTest.php
+++ b/tests/Unit/Config/Initialization/Step/VcsConfigStepTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Config\Initialization\Step;
+
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Tests;
+use CPSIT\FrontendAssetHandler\Vcs;
+use Symfony\Component\Console;
+
+/**
+ * VcsConfigStepTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class VcsConfigStepTest extends Tests\Unit\ContainerAwareTestCase
+{
+    use InitializationRequestTrait;
+    use Tests\Unit\InteractiveConsoleInputTrait;
+
+    private Console\Output\BufferedOutput $output;
+    private Config\Initialization\Step\VcsConfigStep $subject;
+    private Config\Initialization\InitializationRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = $this->container->get(Config\Initialization\Step\VcsConfigStep::class);
+        $this->subject->setOutput($this->output);
+        $this->request = $this->createRequest($this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function executeDoesNothingIfUserSkipsConfiguration(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['no'], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame([], $this->request->getConfig()->asArray());
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Add VCS configuration?', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeSkipsUserConfirmationIfVcsTypeRequestOptionIsGiven(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['', '', 'foo', '123', ''], $input);
+
+        $this->request->setOption('vcs-type', Vcs\GitlabVcsProvider::getName());
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            Vcs\GitlabVcsProvider::getName(),
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['type'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringNotContainsString('Add VCS configuration?', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowsErrorIfGivenTargetTypeIsNotSupported(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes', 'foo', Vcs\GitlabVcsProvider::getName(), '', 'foo', '123', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            Vcs\GitlabVcsProvider::getName(),
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['type'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Value "foo" is invalid', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksForBaseUrlForVcsTypeGitlab(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes', Vcs\GitlabVcsProvider::getName(), 'https://www.example.com', 'foo', '123', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'https://www.example.com',
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['base-url'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Base URL', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksForAccessTokenForVcsTypeGitlab(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes', Vcs\GitlabVcsProvider::getName(), '', 'foo', '123', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'foo',
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['access-token'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Access token', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksForProjectIdForVcsTypeGitlab(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes', Vcs\GitlabVcsProvider::getName(), '', 'foo', '123', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            123,
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['project-id'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Project ID', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowErrorIfGivenVcsConfigExtraIsNotValidJson(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes', Vcs\GitlabVcsProvider::getName(), '', 'foo', '123', 'foo', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('JSON is invalid.', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeMergesVcsConfigExtraWithAdditionalVariables(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes', Vcs\GitlabVcsProvider::getName(), '', 'foo', '123', '{"foo":"baz"}'], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'https://gitlab.com',
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['base-url'],
+        );
+        self::assertSame(
+            'foo',
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['access-token'],
+        );
+        self::assertSame(
+            123,
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['project-id'],
+        );
+        self::assertSame(
+            'baz',
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['foo'],
+        );
+    }
+}

--- a/tests/Unit/Console/Input/Validator/ChainedValidatorTest.php
+++ b/tests/Unit/Console/Input/Validator/ChainedValidatorTest.php
@@ -24,59 +24,40 @@ declare(strict_types=1);
 namespace CPSIT\FrontendAssetHandler\Tests\Unit\Console\Input\Validator;
 
 use CPSIT\FrontendAssetHandler\Console;
+use CPSIT\FrontendAssetHandler\Tests;
 use PHPUnit\Framework\TestCase;
-use Webmozart\Assert;
 
 /**
- * UrlValidatorTest.
+ * ChainedValidatorTest.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class UrlValidatorTest extends TestCase
+final class ChainedValidatorTest extends TestCase
 {
-    private Console\Input\Validator\UrlValidator $subject;
+    private Console\Input\Validator\ChainedValidator $subject;
+    private Tests\Unit\Fixtures\Classes\DummyValidator $firstValidator;
+    private Tests\Unit\Fixtures\Classes\DummyValidator $secondValidator;
 
     protected function setUp(): void
     {
-        $this->subject = new Console\Input\Validator\UrlValidator();
+        $this->subject = new Console\Input\Validator\ChainedValidator([
+            $this->firstValidator = new Tests\Unit\Fixtures\Classes\DummyValidator(),
+            $this->secondValidator = new Tests\Unit\Fixtures\Classes\DummyValidator(),
+        ]);
     }
 
     /**
      * @test
      */
-    public function validateDoesNothingIfValueIsNull(): void
+    public function validateIteratesThroughAllChainedValidators(): void
     {
-        self::assertNull($this->subject->validate(null));
-    }
-
-    /**
-     * @test
-     */
-    public function validateThrowsExceptionIfValueIsNotAString(): void
-    {
-        $this->expectExceptionObject(new Assert\InvalidArgumentException('Expected a string. Got: bool'));
-
-        $this->subject->validate(false);
-    }
-
-    /**
-     * @test
-     */
-    public function validateThrowsExceptionIfFilteredValueIsNotAValidUrl(): void
-    {
-        $this->expectExceptionObject(new Assert\InvalidArgumentException('The given URL is invalid.'));
+        self::assertFalse($this->firstValidator->hasBeenCalled);
+        self::assertFalse($this->secondValidator->hasBeenCalled);
 
         $this->subject->validate('foo');
-    }
 
-    /**
-     * @test
-     */
-    public function validateReturnsValueOnValidUrl(): void
-    {
-        $url = 'https://www.example.com';
-
-        self::assertSame($url, $this->subject->validate($url));
+        self::assertTrue($this->firstValidator->hasBeenCalled);
+        self::assertTrue($this->secondValidator->hasBeenCalled);
     }
 }

--- a/tests/Unit/Console/Input/Validator/IntegerValidatorTest.php
+++ b/tests/Unit/Console/Input/Validator/IntegerValidatorTest.php
@@ -28,54 +28,24 @@ use PHPUnit\Framework\TestCase;
 use Webmozart\Assert;
 
 /**
- * JsonValidatorTest.
+ * IntegerValidatorTest.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class JsonValidatorTest extends TestCase
+final class IntegerValidatorTest extends TestCase
 {
-    private Console\Input\Validator\JsonValidator $subject;
+    private Console\Input\Validator\IntegerValidator $subject;
 
     protected function setUp(): void
     {
-        $this->subject = new Console\Input\Validator\JsonValidator();
+        $this->subject = new Console\Input\Validator\IntegerValidator();
     }
 
     /**
      * @test
      */
-    public function validateThrowsExceptionIfValueIsNotAString(): void
-    {
-        $this->expectExceptionObject(new Assert\InvalidArgumentException('Expected a string. Got: bool'));
-
-        $this->subject->validate(false);
-    }
-
-    /**
-     * @test
-     */
-    public function validateThrowsExceptionIfValueIsValidJson(): void
-    {
-        $this->expectExceptionObject(new Assert\InvalidArgumentException('JSON is invalid.'));
-
-        $this->subject->validate('foo');
-    }
-
-    /**
-     * @test
-     */
-    public function validateThrowsExceptionIfJsonDecodedValueIsNotAnObject(): void
-    {
-        $this->expectExceptionObject(new Assert\InvalidArgumentException('Expected an object. Got: integer'));
-
-        $this->subject->validate('1');
-    }
-
-    /**
-     * @test
-     */
-    public function validateReturnsValueOnNull(): void
+    public function validateDoesNothingIfValueIsNull(): void
     {
         self::assertNull($this->subject->validate(null));
     }
@@ -83,10 +53,26 @@ final class JsonValidatorTest extends TestCase
     /**
      * @test
      */
-    public function validateReturnsValueOnValidJson(): void
+    public function validateReturnsValueIfItIsAnInteger(): void
     {
-        $json = '{"foo":"baz"}';
+        self::assertSame(123, $this->subject->validate(123));
+    }
 
-        self::assertSame($json, $this->subject->validate($json));
+    /**
+     * @test
+     */
+    public function validateThrowsExceptionIfValueIsNotNumeric(): void
+    {
+        $this->expectExceptionObject(new Assert\InvalidArgumentException('Expected a numeric. Got: bool'));
+
+        $this->subject->validate(false);
+    }
+
+    /**
+     * @test
+     */
+    public function validateReturnsConvertedIntegerValueIfItIsANumericString(): void
+    {
+        self::assertSame(123, $this->subject->validate('123'));
     }
 }

--- a/tests/Unit/Console/Input/Validator/NotEmptyValidatorTest.php
+++ b/tests/Unit/Console/Input/Validator/NotEmptyValidatorTest.php
@@ -35,6 +35,13 @@ use Webmozart\Assert;
  */
 final class NotEmptyValidatorTest extends TestCase
 {
+    private Console\Input\Validator\NotEmptyValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Console\Input\Validator\NotEmptyValidator();
+    }
+
     /**
      * @test
      */
@@ -42,7 +49,7 @@ final class NotEmptyValidatorTest extends TestCase
     {
         $this->expectExceptionObject(new Assert\InvalidArgumentException('Expected a non-empty value. Got: null'));
 
-        Console\Input\Validator\NotEmptyValidator::validate(null);
+        $this->subject->validate(null);
     }
 
     /**
@@ -50,6 +57,6 @@ final class NotEmptyValidatorTest extends TestCase
      */
     public function validateReturnsValueOnNonEmptyValue(): void
     {
-        self::assertSame('foo', Console\Input\Validator\NotEmptyValidator::validate('foo'));
+        self::assertSame('foo', $this->subject->validate('foo'));
     }
 }

--- a/tests/Unit/Console/Input/Validator/ValidatorFactoryTest.php
+++ b/tests/Unit/Console/Input/Validator/ValidatorFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Console\Input\Validator;
+
+use CPSIT\FrontendAssetHandler\Console;
+use CPSIT\FrontendAssetHandler\Exception;
+use Generator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ValidatorFactoryTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class ValidatorFactoryTest extends TestCase
+{
+    private Console\Input\Validator\ValidatorFactory $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Console\Input\Validator\ValidatorFactory();
+    }
+
+    /**
+     * @test
+     */
+    public function getThrowsExceptionIfGivenTypeIsNotSupported(): void
+    {
+        $this->expectExceptionObject(Exception\UnsupportedTypeException::create('foo'));
+
+        $this->subject->get('foo');
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getReturnsValidatorOfGivenTypeDataProvider
+     */
+    public function getReturnsValidatorOfGivenType(
+        string $type,
+        Console\Input\Validator\ValidatorInterface $expected,
+    ): void {
+        self::assertEquals($expected, $this->subject->get($type));
+    }
+
+    /**
+     * @test
+     */
+    public function getForAllReturnsChainedValidator(): void
+    {
+        $expected = new Console\Input\Validator\ChainedValidator([
+            new Console\Input\Validator\NotEmptyValidator(),
+            new Console\Input\Validator\UrlValidator(),
+        ]);
+
+        self::assertEquals($expected, $this->subject->getForAll(['notEmpty', 'url']));
+    }
+
+    /**
+     * @return Generator<string, array{string, Console\Input\Validator\ValidatorInterface}>
+     */
+    public function getReturnsValidatorOfGivenTypeDataProvider(): Generator
+    {
+        yield 'integer validator' => ['integer', new Console\Input\Validator\IntegerValidator()];
+        yield 'json validator' => ['json', new Console\Input\Validator\JsonValidator()];
+        yield 'notEmpty validator' => ['notEmpty', new Console\Input\Validator\NotEmptyValidator()];
+        yield 'url validator' => ['url', new Console\Input\Validator\UrlValidator()];
+    }
+}

--- a/tests/Unit/Exception/UnexpectedValueExceptionTest.php
+++ b/tests/Unit/Exception/UnexpectedValueExceptionTest.php
@@ -21,30 +21,28 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Exception;
 
-use Webmozart\Assert;
-
-use function json_decode;
+use CPSIT\FrontendAssetHandler\Exception;
+use PHPUnit\Framework\TestCase;
 
 /**
- * JsonValidator.
+ * UnexpectedValueExceptionTest.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class JsonValidator implements ValidatorInterface
+final class UnexpectedValueExceptionTest extends TestCase
 {
-    public function validate(mixed $value): mixed
+    /**
+     * @test
+     */
+    public function forInvalidStringReturnsExceptionForGivenString(): void
     {
-        if (null !== $value) {
-            Assert\Assert::string($value);
-            Assert\Assert::notNull($json = json_decode((string) $value), 'JSON is invalid.');
-            Assert\Assert::object($json);
-        }
+        $actual = Exception\UnexpectedValueException::forInvalidString('foo');
 
-        return $value;
+        self::assertInstanceOf(Exception\UnexpectedValueException::class, $actual);
+        self::assertSame('The string "foo" is invalid and cannot be processed.', $actual->getMessage());
+        self::assertSame(1663166818, $actual->getCode());
     }
 }

--- a/tests/Unit/Fixtures/Classes/DummyInteractiveStep.php
+++ b/tests/Unit/Fixtures/Classes/DummyInteractiveStep.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes;
+
+use CPSIT\FrontendAssetHandler\ChattyInterface;
+use CPSIT\FrontendAssetHandler\Config;
+use CPSIT\FrontendAssetHandler\Console;
+use CPSIT\FrontendAssetHandler\Traits;
+use Symfony\Component\Console as SymfonyConsole;
+
+/**
+ * DummyInteractiveStep.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class DummyInteractiveStep implements Config\Initialization\Step\InteractiveStepInterface, ChattyInterface
+{
+    use Traits\OutputAwareTrait;
+
+    public ?Config\Config $expectedConfig = null;
+
+    public function __construct()
+    {
+        $this->setOutput(new SymfonyConsole\Output\NullOutput());
+    }
+
+    public function getInputOptions(): array
+    {
+        return [
+            new SymfonyConsole\Input\InputOption('config', mode: SymfonyConsole\Input\InputOption::VALUE_REQUIRED),
+            new SymfonyConsole\Input\InputOption('foo', mode: SymfonyConsole\Input\InputOption::VALUE_REQUIRED),
+            new SymfonyConsole\Input\InputOption('baz', mode: SymfonyConsole\Input\InputOption::VALUE_REQUIRED, default: 'baz'),
+        ];
+    }
+
+    public function execute(Config\Initialization\InitializationRequest $request): bool
+    {
+        if (null !== $this->expectedConfig) {
+            $request->setConfig($this->expectedConfig);
+        }
+
+        $request->getConfig()['frontend-assets'][0]['request-options'] = $request->getOptions();
+
+        return true;
+    }
+
+    public function getOutput(): Console\Output\TrackableOutput
+    {
+        return $this->output;
+    }
+}

--- a/tests/Unit/Fixtures/Classes/DummyStep.php
+++ b/tests/Unit/Fixtures/Classes/DummyStep.php
@@ -21,30 +21,22 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes;
 
-use Webmozart\Assert;
-
-use function json_decode;
+use CPSIT\FrontendAssetHandler\Config;
 
 /**
- * JsonValidator.
+ * DummyStep.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class JsonValidator implements ValidatorInterface
+final class DummyStep implements Config\Initialization\Step\StepInterface
 {
-    public function validate(mixed $value): mixed
-    {
-        if (null !== $value) {
-            Assert\Assert::string($value);
-            Assert\Assert::notNull($json = json_decode((string) $value), 'JSON is invalid.');
-            Assert\Assert::object($json);
-        }
+    public bool $expectedReturn = true;
 
-        return $value;
+    public function execute(Config\Initialization\InitializationRequest $request): bool
+    {
+        return $this->expectedReturn;
     }
 }

--- a/tests/Unit/Fixtures/Classes/DummyValidator.php
+++ b/tests/Unit/Fixtures/Classes/DummyValidator.php
@@ -21,29 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\FrontendAssetHandler\Console\Input\Validator;
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Fixtures\Classes;
 
-use Webmozart\Assert;
-
-use function json_decode;
+use CPSIT\FrontendAssetHandler\Console;
 
 /**
- * JsonValidator.
+ * DummyValidator.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class JsonValidator implements ValidatorInterface
+final class DummyValidator implements Console\Input\Validator\ValidatorInterface
 {
+    public bool $hasBeenCalled = false;
+
     public function validate(mixed $value): mixed
     {
-        if (null !== $value) {
-            Assert\Assert::string($value);
-            Assert\Assert::notNull($json = json_decode((string) $value), 'JSON is invalid.');
-            Assert\Assert::object($json);
-        }
+        $this->hasBeenCalled = true;
 
         return $value;
     }

--- a/tests/Unit/Helper/StringHelperTest.php
+++ b/tests/Unit/Helper/StringHelperTest.php
@@ -88,6 +88,16 @@ final class StringHelperTest extends TestCase
 
     /**
      * @test
+     */
+    public function extractPlaceholdersReturnsExtractedAndResolvedPlaceholdersFromGivenString(): void
+    {
+        $string = 'Hello, my name is {name}! I\'m living in {city}.';
+
+        self::assertSame(['name', 'city'], Helper\StringHelper::extractPlaceholders($string));
+    }
+
+    /**
+     * @test
      *
      * @dataProvider urlEncodeReturnsUrlEncodedValueDataProvider
      */

--- a/tests/Unit/InteractiveConsoleInputTrait.php
+++ b/tests/Unit/InteractiveConsoleInputTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit;
+
+use Symfony\Component\Console;
+
+/**
+ * InteractiveConsoleInputTrait.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+trait InteractiveConsoleInputTrait
+{
+    /**
+     * @param list<string> $inputs
+     */
+    private static function setInputs(array $inputs, Console\Input\StreamableInputInterface $input): void
+    {
+        $input->setStream(self::createStream($inputs));
+    }
+
+    /**
+     * This code snippet is originally taken from Symfony's source code.
+     * See license at https://github.com/symfony/symfony/blob/6.1/LICENSE.
+     *
+     * (c) Fabien Potencier <fabien@symfony.com>
+     *
+     * @param list<string> $inputs
+     *
+     * @return resource
+     *
+     * @see https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Console/Tester/TesterTrait.php
+     */
+    private static function createStream(array $inputs)
+    {
+        $stream = fopen('php://memory', 'r+');
+
+        self::assertIsResource($stream);
+
+        foreach ($inputs as $input) {
+            fwrite($stream, $input.\PHP_EOL);
+        }
+
+        rewind($stream);
+
+        return $stream;
+    }
+}

--- a/tests/Unit/Vcs/GitlabVcsProviderTest.php
+++ b/tests/Unit/Vcs/GitlabVcsProviderTest.php
@@ -61,20 +61,6 @@ final class GitlabVcsProviderTest extends TestCase
     /**
      * @test
      */
-    public function withVcsThrowsExceptionIfBaseUrlIsMissing(): void
-    {
-        unset($this->vcs['base-url']);
-
-        $this->expectException(Exception\MissingConfigurationException::class);
-        $this->expectExceptionCode(1623867663);
-        $this->expectExceptionMessage('Configuration for key "base-url" is missing or invalid.');
-
-        $this->subject->withVcs($this->vcs);
-    }
-
-    /**
-     * @test
-     */
     public function withVcsThrowsExceptionIfAccessTokenIsMissing(): void
     {
         unset($this->vcs['access-token']);


### PR DESCRIPTION
This PR splits the bloated `init` command into so-called "configuration initialization steps". This makes it easier to maintain the different steps that are processed while initializing a new asset configuration.