### PR TITLE
[BUGFIX] Restore phar artifact in correct path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: phar
+          path: .build
       - name: Make PHAR executable
         run: chmod +x .build/frontend-asset-handler.phar
 


### PR DESCRIPTION
The phar artifact generated by the release workflow is now restored in the expected build path.