### PR TITLE
[BUGFIX] Include version in source config initialization step

### DIFF
--- a/src/Config/Initialization/Step/SourceConfigStep.php
+++ b/src/Config/Initialization/Step/SourceConfigStep.php
@@ -72,6 +72,12 @@ final class SourceConfigStep extends BaseStep implements InteractiveStepInterfac
                 'URL to locate the revision of asset source files, can contain placeholders in the form {<config key>}',
             ),
             new Console\Input\InputOption(
+                'source-version',
+                null,
+                Console\Input\InputOption::VALUE_REQUIRED,
+                'Locked version of an asset source to be used for the stable environment',
+            ),
+            new Console\Input\InputOption(
                 'source-config-extra',
                 null,
                 Console\Input\InputOption::VALUE_REQUIRED,
@@ -142,6 +148,17 @@ final class SourceConfigStep extends BaseStep implements InteractiveStepInterfac
             $additionalVariables,
         );
 
+        // Source version
+        $sourceVersion = $this->questionHelper->ask(
+            $input,
+            $this->output,
+            $this->createQuestion(
+                'Locked version',
+                $request->getOption('source-version'),
+            ),
+        );
+        $request->setOption('source-version', $sourceVersion);
+
         // Source config extra
         $sourceConfigExtra = $this->questionHelper->ask(
             $input,
@@ -182,6 +199,11 @@ final class SourceConfigStep extends BaseStep implements InteractiveStepInterfac
         // Add revision URL
         if (is_string($request->getOption('source-revision-url'))) {
             $sourceConfig['revision-url'] = $request->getOption('source-revision-url');
+        }
+
+        // Add version
+        if (is_string($request->getOption('source-version'))) {
+            $sourceConfig['version'] = $request->getOption('source-version');
         }
 
         // Merge additional source configuration

--- a/tests/Unit/Config/Initialization/Step/SourceConfigStepTest.php
+++ b/tests/Unit/Config/Initialization/Step/SourceConfigStepTest.php
@@ -62,7 +62,7 @@ final class SourceConfigStepTest extends Tests\Unit\ContainerAwareTestCase
 
         self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
 
-        self::setInputs(['', 'https://www.example.com', '', ''], $input);
+        self::setInputs(['', 'https://www.example.com', '', '', ''], $input);
 
         self::assertTrue($this->subject->execute($this->request));
         self::assertSame(
@@ -80,7 +80,7 @@ final class SourceConfigStepTest extends Tests\Unit\ContainerAwareTestCase
 
         self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
 
-        self::setInputs(['foo', '', 'https://www.example.com', '', ''], $input);
+        self::setInputs(['foo', '', 'https://www.example.com', '', '', ''], $input);
 
         self::assertTrue($this->subject->execute($this->request));
         self::assertSame(
@@ -102,7 +102,7 @@ final class SourceConfigStepTest extends Tests\Unit\ContainerAwareTestCase
 
         self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
 
-        self::setInputs(['', 'https://www.example.com/{environment}/{foo}', 'foo', '', ''], $input);
+        self::setInputs(['', 'https://www.example.com/{environment}/{foo}', 'foo', '', '', ''], $input);
 
         self::assertTrue($this->subject->execute($this->request));
         self::assertSame(
@@ -129,7 +129,7 @@ final class SourceConfigStepTest extends Tests\Unit\ContainerAwareTestCase
         self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
 
         self::setInputs(
-            ['', 'https://www.example.com/', 'https://www.example.com/{revision-file}', 'revision.txt', ''],
+            ['', 'https://www.example.com/', 'https://www.example.com/{revision-file}', 'revision.txt', '', ''],
             $input,
         );
 
@@ -151,6 +151,31 @@ final class SourceConfigStepTest extends Tests\Unit\ContainerAwareTestCase
     /**
      * @test
      */
+    public function executeAsksForSourceVersion(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(
+            ['', 'https://www.example.com/', 'https://www.example.com/REVISION', '1.0.0', ''],
+            $input,
+        );
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            '1.0.0',
+            $this->request->getConfig()['frontend-assets'][0]['source']['version'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Locked version', $output);
+    }
+
+    /**
+     * @test
+     */
     public function executeShowErrorIfGivenSourceConfigExtraIsNotValidJson(): void
     {
         $input = $this->request->getInput();
@@ -158,7 +183,7 @@ final class SourceConfigStepTest extends Tests\Unit\ContainerAwareTestCase
         self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
 
         self::setInputs(
-            ['', 'https://www.example.com/', '', 'foo', ''],
+            ['', 'https://www.example.com/', '', '', 'foo', ''],
             $input,
         );
 
@@ -179,7 +204,7 @@ final class SourceConfigStepTest extends Tests\Unit\ContainerAwareTestCase
         self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
 
         self::setInputs(
-            ['', 'https://www.example.com/{foo}', 'foo', 'https://www.example.com/{baz}', 'baz', '{"hello":"world"}'],
+            ['', 'https://www.example.com/{foo}', 'foo', 'https://www.example.com/{baz}', 'baz', '', '{"hello":"world"}'],
             $input,
         );
 


### PR DESCRIPTION
The `source.version` config was forgotten when implementing the source config step. It is now added.