### PR TITLE
[BUGFIX] Respect default source and target types

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -17,7 +17,7 @@
 * Console command `wait-for-assets` was rewritten.
   - Use `vendor/bin/frontend-assets inspect --wait-for-deployments` instead.
 * Configuration schema was hardened.
-  - Add a `type` configuration to all `source`, `target` and `vcs` definitions.
+  - Add a `type` configuration to the `vcs` definition.
   - Explicitly configure `url` and `revision-url` for the `source` definition.
   - Migrate the `source.revision-file` configuration to `source.revision-url`:
     ```diff

--- a/resources/configuration.schema.json
+++ b/resources/configuration.schema.json
@@ -49,7 +49,6 @@
 			"title": "Frontend asset source",
 			"description": "Definition of the Frontend asset source of a concrete Frontend asset definition.",
 			"required": [
-				"type",
 				"url"
 			],
 			"properties": {
@@ -82,7 +81,6 @@
 			"title": "Frontend asset target",
 			"description": "Definition of the Frontend asset target of a concrete Frontend asset definition.",
 			"required": [
-				"type",
 				"path"
 			],
 			"properties": {

--- a/tests/Unit/Command/ConfigAssetsCommandTest.php
+++ b/tests/Unit/Command/ConfigAssetsCommandTest.php
@@ -139,11 +139,11 @@ final class ConfigAssetsCommandTest extends Tests\Unit\CommandTesterAwareTestCas
         $this->expectException(Exception\InvalidConfigurationException::class);
         $this->expectExceptionCode(1643113965);
         $this->expectExceptionMessage(
-            'The configuration is invalid: '.PHP_EOL.'  * [/frontend-assets/0/source/type]: The property type is required'
+            'The configuration is invalid: '.PHP_EOL.'  * [/frontend-assets/0/source/url]: The property url is required'
         );
 
         $this->commandTester->execute([
-            'path' => '0/source/type',
+            'path' => '0/source/url',
             '--unset' => true,
         ]);
     }
@@ -163,7 +163,6 @@ final class ConfigAssetsCommandTest extends Tests\Unit\CommandTesterAwareTestCas
         self::assertSame(8, $exitCode);
         self::assertStringContainsString('Your asset configuration is invalid.', $output);
         self::assertMatchesRegularExpression('/\[0]\[target]\s+The property target is required/', $output);
-        self::assertMatchesRegularExpression('/\[0]\[source]\[type]\s+The property type is required/', $output);
         self::assertMatchesRegularExpression('/\[0]\[source]\[url]\s+The property url is required/', $output);
     }
 


### PR DESCRIPTION
This PR partially reverts changes introduced with 1.0.0 regarding required `type` configuration for `source` and `target` definitions: Since the library ships default providers and processors, we use those types as fallback and make the `type` configuration optional.

Resolves: #22