### PR TITLE
[BUGFIX] Follow-up: Require a type when building a `Vcs` object

### DIFF
--- a/resources/configuration.schema.json
+++ b/resources/configuration.schema.json
@@ -115,8 +115,7 @@
 				"type": {
 					"type": "string",
 					"title": "Asset VCS type",
-					"description": "Type of a concrete Frontend asset VCS provider (an appropriate Provider must exist).",
-					"default": "gitlab"
+					"description": "Type of a concrete Frontend asset VCS provider (an appropriate Provider must exist)."
 				}
 			},
 			"additionalProperties": true

--- a/src/Asset/Definition/Vcs.php
+++ b/src/Asset/Definition/Vcs.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Asset\Definition;
 
-use CPSIT\FrontendAssetHandler\Vcs\GitlabVcsProvider;
+use CPSIT\FrontendAssetHandler\Exception;
 
 /**
  * Vcs.
@@ -33,10 +33,17 @@ use CPSIT\FrontendAssetHandler\Vcs\GitlabVcsProvider;
  */
 class Vcs extends AssetDefinition
 {
-    protected array $defaults = [
-        /* @see GitlabVcsProvider::getName() */
-        'type' => 'gitlab',
-    ];
+    /**
+     * @throws Exception\MissingConfigurationException
+     */
+    public function __construct(array $config)
+    {
+        parent::__construct($config);
+
+        if (!isset($config['type'])) {
+            throw Exception\MissingConfigurationException::forKey('vcs/type');
+        }
+    }
 
     public function getType(): string
     {

--- a/tests/Unit/Asset/Definition/AssetDefinitionFactoryTest.php
+++ b/tests/Unit/Asset/Definition/AssetDefinitionFactoryTest.php
@@ -144,7 +144,10 @@ final class AssetDefinitionFactoryTest extends ContainerAwareTestCase
      */
     public function buildVcsReturnsGeneratedVcsDataProvider(): Generator
     {
-        $buildVcs = fn (string $environment): Vcs => new Vcs(['environment' => $environment]);
+        $buildVcs = fn (string $environment): Vcs => new Vcs([
+            'type' => GitlabVcsProvider::getName(),
+            'environment' => $environment,
+        ]);
 
         yield 'custom map' => [
             [

--- a/tests/Unit/Asset/Definition/VcsTest.php
+++ b/tests/Unit/Asset/Definition/VcsTest.php
@@ -23,7 +23,8 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Tests\Unit\Asset\Definition;
 
-use CPSIT\FrontendAssetHandler\Asset\Definition\Vcs;
+use CPSIT\FrontendAssetHandler\Asset;
+use CPSIT\FrontendAssetHandler\Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,11 +35,21 @@ use PHPUnit\Framework\TestCase;
  */
 final class VcsTest extends TestCase
 {
-    private Vcs $subject;
+    private Asset\Definition\Vcs $subject;
 
     protected function setUp(): void
     {
-        $this->subject = new Vcs([]);
+        $this->subject = new Asset\Definition\Vcs(['type' => 'foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function constructorThrowsExceptionIfTypeIsMissing(): void
+    {
+        $this->expectExceptionObject(Exception\MissingConfigurationException::forKey('vcs/type'));
+
+        new Asset\Definition\Vcs([]);
     }
 
     /**
@@ -46,10 +57,10 @@ final class VcsTest extends TestCase
      */
     public function getTypeReturnsType(): void
     {
-        self::assertSame('gitlab', $this->subject->getType());
-
-        $this->subject['type'] = 'foo';
         self::assertSame('foo', $this->subject->getType());
+
+        $this->subject['type'] = 'baz';
+        self::assertSame('baz', $this->subject->getType());
     }
 
     /**

--- a/tests/Unit/Vcs/GitlabVcsProviderTest.php
+++ b/tests/Unit/Vcs/GitlabVcsProviderTest.php
@@ -50,6 +50,7 @@ final class GitlabVcsProviderTest extends TestCase
     protected function setUp(): void
     {
         $this->vcs = new Asset\Definition\Vcs([
+            'type' => Vcs\GitlabVcsProvider::getName(),
             'base-url' => 'https://gitlab.example.com',
             'project-id' => 123,
             'access-token' => 'foo',

--- a/tests/Unit/Vcs/VcsProviderFactoryTest.php
+++ b/tests/Unit/Vcs/VcsProviderFactoryTest.php
@@ -83,7 +83,7 @@ final class VcsProviderFactoryTest extends Tests\Unit\ContainerAwareTestCase
     {
         self::assertInstanceOf(
             Tests\Unit\Fixtures\Classes\DummyVcsProvider::class,
-            $this->subject->get('dummy', new Asset\Definition\Vcs([])),
+            $this->subject->get('dummy', new Asset\Definition\Vcs(['type' => 'dummy'])),
         );
     }
 


### PR DESCRIPTION
With 1.0.0, declaring a `type` for the `vcs` definition was made a required configuration. However, both the schema and the appropriate `Vcs` definition class still provided `gitlab` as default type in case no `type` was set. This is now fixed and the `vcs` definition does no longer provide a default type.