### PR TITLE
[FEATURE] Add support for GitHub as VCS provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"ergebnis/json-normalizer": ">= 1.0 < 3.0",
 		"ergebnis/json-printer": "^3.0",
 		"ergebnis/json-schema-validator": "^2.0",
+		"gmostafa/php-graphql-client": "^1.13",
 		"guzzlehttp/guzzle": "^7.0",
 		"guzzlehttp/psr7": ">= 1.8 < 3.0",
 		"justinrainbow/json-schema": "^5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e890cc54378889b4ce694f50ebd54ed8",
+    "content-hash": "c0113acaeea5316f12f153a0b3f759e0",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",
@@ -204,6 +204,71 @@
                 }
             ],
             "time": "2021-12-13T16:54:56+00:00"
+        },
+        {
+            "name": "gmostafa/php-graphql-client",
+            "version": "v1.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mghoneimy/php-graphql-client.git",
+                "reference": "caadeba3e8af0d3d5cf6481e393cf933f3a83f3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mghoneimy/php-graphql-client/zipball/caadeba3e8af0d3d5cf6481e393cf933f3a83f3c",
+                "reference": "caadeba3e8af0d3d5cf6481e393cf933f3a83f3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.3|^7.0.1",
+                "php": "^7.1 || ^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "conflict": {
+                "guzzlehttp/psr7": "< 1.7.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.186",
+                "codacy/coverage": "^1.4",
+                "phpunit/phpunit": "^7.5|^8.0|^9.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Move this package to require section to use AWS IAM authorization",
+                "gmostafa/php-graphql-oqm": "To have object-to-query mapping support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mostafa Ghoneimy",
+                    "email": "emostafagh@gmail.com"
+                }
+            ],
+            "description": "GraphQL client and query builder.",
+            "keywords": [
+                "builder",
+                "client",
+                "graph-ql",
+                "graphql",
+                "php",
+                "query",
+                "query-builder"
+            ],
+            "support": {
+                "issues": "https://github.com/mghoneimy/php-graphql-client/issues",
+                "source": "https://github.com/mghoneimy/php-graphql-client/tree/v1.13"
+            },
+            "time": "2021-08-10T12:39:57+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/docs/components/vcs-providers.md
+++ b/docs/components/vcs-providers.md
@@ -1,9 +1,12 @@
 # VCS Providers
 
+The Frontend Assets Handler is able to interact with the asset sources on VCS through
+specific providers. Each VCS provider requires configuration. Consult the appropriate
+provider classes to find out what configuration is expected.
+
 ## [`GithubVcsProvider`](../../src/Vcs/GithubVcsProvider.php)
 
-There exists a VCS provider to support Frontend assets hosted on github.com. For
-this, an access token with `repo` scope is required.
+Interacting with assets on GitHub requires an access token with `repo` scope.
 
 It supports the following additional configuration:
 

--- a/docs/components/vcs-providers.md
+++ b/docs/components/vcs-providers.md
@@ -1,5 +1,28 @@
 # VCS Providers
 
+## [`GithubVcsProvider`](../../src/Vcs/GithubVcsProvider.php)
+
+There exists a VCS provider to support Frontend assets hosted on github.com. For
+this, an access token with `repo` scope is required.
+
+It supports the following additional configuration:
+
+### `access-token`
+
+An access token to identify requests to the GitLab API. This token is supplied as a
+`Authorization` header with each request.
+
+* Required: **yes**
+* Default: **–**
+
+### `repository`
+
+Name of the project in the form `<owner>/<name>` providing the Frontend assets. It
+is used to lookup revisions and current deployments.
+
+* Require: **yes**
+* Default: **–**
+
 ## [`GitlabVcsProvider`](../../src/Vcs/GitlabVcsProvider.php)
 
 Using this VCS Provider, GitLab can be interacted with as the VCS for the requested

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,5 +12,7 @@ parameters:
 	symfony:
 		consoleApplicationLoader: tests/Build/console-application.php
 		containerXmlPath: var/cache/container_test.xml
+	stubFiles:
+		- tests/Build/Stubs/GraphQL/QueryBuilder.stub
 	scanFiles:
 		- var/cache/container_test.php

--- a/src/Config/Initialization/Step/VcsConfigStep.php
+++ b/src/Config/Initialization/Step/VcsConfigStep.php
@@ -93,32 +93,15 @@ final class VcsConfigStep extends BaseStep implements InteractiveStepInterface
         );
         $request->setOption('vcs-type', $vcsType);
 
-        // Additional variables for GitlabVcsProvider only
-        if (Vcs\GitlabVcsProvider::getName() === $vcsType) {
-            $this->askForAdditionalVariable(
-                $request,
-                'Base URL',
-                'base-url',
-                $additionalVariables,
-                'https://gitlab.com',
-                ['notEmpty', 'url'],
-            );
+        // Additional variables for specific providers
+        switch ($vcsType) {
+            case Vcs\GitlabVcsProvider::getName():
+                $this->requestAdditionalVariablesForGitlabVcsProvider($request, $additionalVariables);
+                break;
 
-            $this->askForAdditionalVariable(
-                $request,
-                'Access token',
-                'access-token',
-                $additionalVariables,
-                validator: 'notEmpty',
-            );
-
-            $this->askForAdditionalVariable(
-                $request,
-                'Project ID',
-                'project-id',
-                $additionalVariables,
-                validator: 'integer',
-            );
+            case Vcs\GithubVcsProvider::getName():
+                $this->requestAdditionalVariablesForGithubVcsProvider($request, $additionalVariables);
+                break;
         }
 
         // VCS config extra
@@ -145,6 +128,63 @@ final class VcsConfigStep extends BaseStep implements InteractiveStepInterface
         $this->buildVcs($request);
 
         return true;
+    }
+
+    /**
+     * @param array<string, mixed> $additionalVariables
+     */
+    private function requestAdditionalVariablesForGitlabVcsProvider(
+        Config\Initialization\InitializationRequest $request,
+        array &$additionalVariables,
+    ): void {
+        $this->askForAdditionalVariable(
+            $request,
+            'Base URL',
+            'base-url',
+            $additionalVariables,
+            'https://gitlab.com',
+            ['notEmpty', 'url'],
+        );
+
+        $this->askForAdditionalVariable(
+            $request,
+            'Access token',
+            'access-token',
+            $additionalVariables,
+            validator: 'notEmpty',
+        );
+
+        $this->askForAdditionalVariable(
+            $request,
+            'Project ID',
+            'project-id',
+            $additionalVariables,
+            validator: 'integer',
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $additionalVariables
+     */
+    private function requestAdditionalVariablesForGithubVcsProvider(
+        Config\Initialization\InitializationRequest $request,
+        array &$additionalVariables,
+    ): void {
+        $this->askForAdditionalVariable(
+            $request,
+            'Access token',
+            'access-token',
+            $additionalVariables,
+            validator: 'notEmpty',
+        );
+
+        $this->askForAdditionalVariable(
+            $request,
+            'Repository (<owner>/<name>)',
+            'repository',
+            $additionalVariables,
+            validator: 'notEmpty',
+        );
     }
 
     private function buildVcs(Config\Initialization\InitializationRequest $request): void

--- a/src/Vcs/GithubVcsProvider.php
+++ b/src/Vcs/GithubVcsProvider.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Vcs;
+
+use CPSIT\FrontendAssetHandler\Asset;
+use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Helper;
+use CPSIT\FrontendAssetHandler\Traits;
+use GraphQL\Client;
+use GraphQL\QueryBuilder;
+use GraphQL\RawObject;
+use GraphQL\Results;
+use GraphQL\Util;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7;
+
+use function explode;
+use function in_array;
+use function is_array;
+
+/**
+ * GithubVcsProvider.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class GithubVcsProvider implements DeployableVcsProviderInterface
+{
+    use Traits\DefaultConfigurationAwareTrait;
+
+    private const API_URL = 'https://api.github.com/graphql';
+    private const SUCCESSFUL_DEPLOYMENT_STATUS = 'SUCCESS';
+    private const ACTIVE_DEPLOYMENT_STATUSES = [
+        'PENDING',
+        'QUEUED',
+        'IN_PROGRESS',
+        'WAITING',
+    ];
+
+    private const DEFAULT_CONFIGURATION = [
+        'access-token' => null,
+        'repository' => null,
+    ];
+
+    private ?Client $graphQlClient = null;
+
+    public function __construct(
+        private readonly ClientInterface $client,
+        private ?string $accessToken = null,
+        private ?string $owner = null,
+        private ?string $name = null,
+        private ?string $environment = null,
+    ) {
+    }
+
+    public function withVcs(Asset\Definition\Vcs $vcs): static
+    {
+        // Validate and merge VCS configuration
+        $this->validateAssetDefinition($vcs);
+        $this->applyDefaultConfiguration($vcs);
+
+        // Apply VCS configuration
+        $clone = clone $this;
+        $clone->graphQlClient = null;
+        $clone->accessToken = (string) $vcs['access-token'];
+        [$clone->owner, $clone->name] = explode('/', (string) $vcs['repository'], 2);
+        $clone->environment = $vcs->getEnvironment();
+
+        return $clone;
+    }
+
+    public static function getName(): string
+    {
+        return 'github';
+    }
+
+    public function getSourceUrl(): string
+    {
+        $results = $this->sendRequest(
+            $this->createQueryBuilder()->selectField('url'),
+        );
+
+        return Helper\ArrayHelper::getArrayValueByPath(
+            $this->parseGraphQLData($results),
+            'repository/url',
+        );
+    }
+
+    public function getLatestRevision(string $environment = null): ?Asset\Revision\Revision
+    {
+        try {
+            $results = $this->sendRequest(
+                $this->createQueryBuilder()->selectField(
+                    (new QueryBuilder\QueryBuilder('deployments'))
+                        ->setArgument('environments', $environment ?? $this->environment)
+                        ->setArgument('first', 30)
+                        ->setArgument('orderBy', new RawObject('{field:CREATED_AT, direction:DESC}'))
+                        ->selectField(
+                            (new QueryBuilder\QueryBuilder('nodes'))
+                                ->selectField('commitOid')
+                                ->selectField(
+                                    (new QueryBuilder\QueryBuilder('latestStatus'))
+                                        ->selectField('state')
+                                )
+                        )
+                ),
+            );
+
+            $nodes = Helper\ArrayHelper::getArrayValueByPath(
+                $this->parseGraphQLData($results),
+                'repository/deployments/nodes',
+            );
+        } catch (\Exception) {
+            return null;
+        }
+
+        // Find latest successful deployment
+        foreach ($nodes as $node) {
+            if (self::SUCCESSFUL_DEPLOYMENT_STATUS === $node['latestStatus']['state']) {
+                return new Asset\Revision\Revision($node['commitOid']);
+            }
+        }
+
+        return null;
+    }
+
+    public function hasRevision(Asset\Revision\Revision $revision): bool
+    {
+        try {
+            $results = $this->sendRequest(
+                $this->createQueryBuilder()->selectField(
+                    (new QueryBuilder\QueryBuilder('object'))
+                        ->setArgument('oid', $revision->get())
+                        ->selectField('id')
+                ),
+            );
+
+            return null !== Helper\ArrayHelper::getArrayValueByPath(
+                $this->parseGraphQLData($results),
+                'repository/object',
+            );
+        } catch (\Exception) {
+            return false;
+        }
+    }
+
+    public function getActiveDeployments(): array
+    {
+        $deployments = [];
+
+        $results = $this->sendRequest(
+            $this->createQueryBuilder()->selectField(
+                (new QueryBuilder\QueryBuilder('deployments'))
+                    ->setArgument('environments', $this->environment)
+                    ->setArgument('first', 30)
+                    ->setArgument('orderBy', new RawObject('{field:CREATED_AT, direction:DESC}'))
+                    ->selectField(
+                        (new QueryBuilder\QueryBuilder('nodes'))
+                            ->selectField('commitOid')
+                            ->selectField(
+                                (new QueryBuilder\QueryBuilder('latestStatus'))
+                                    ->selectField('logUrl')
+                                    ->selectField('state')
+                            )
+                    )
+            ),
+        );
+
+        $nodes = Helper\ArrayHelper::getArrayValueByPath(
+            $this->parseGraphQLData($results),
+            'repository/deployments/nodes',
+        );
+
+        foreach ($nodes as $node) {
+            if (in_array($node['latestStatus']['state'], self::ACTIVE_DEPLOYMENT_STATUSES, true)) {
+                $deployments[] = new Dto\Deployment(
+                    new Psr7\Uri($node['latestStatus']['logUrl']),
+                    new Asset\Revision\Revision($node['commitOid']),
+                );
+            }
+        }
+
+        return $deployments;
+    }
+
+    private function createQueryBuilder(): QueryBuilder\QueryBuilder
+    {
+        return (new QueryBuilder\QueryBuilder('repository'))
+            ->setArgument('owner', $this->owner)
+            ->setArgument('name', $this->name)
+        ;
+    }
+
+    private function sendRequest(QueryBuilder\QueryBuilder $queryBuilder): Results
+    {
+        return $this->getClient()->runQuery(
+            (new QueryBuilder\QueryBuilder())->selectField($queryBuilder),
+            true,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws Exception\InvalidResponseException
+     */
+    private function parseGraphQLData(Results $results): array
+    {
+        $data = $results->getData();
+
+        if (!is_array($data)) {
+            throw Exception\InvalidResponseException::create($results->getResponseBody());
+        }
+
+        return $data;
+    }
+
+    private function getClient(): Client
+    {
+        if (null === $this->graphQlClient) {
+            $this->graphQlClient = new Client(
+                self::API_URL,
+                ['Authorization' => 'Bearer '.$this->accessToken],
+                httpClient: new Util\GuzzleAdapter($this->client),
+            );
+        }
+
+        return $this->graphQlClient;
+    }
+
+    /**
+     * @return array{access-token: string|null, repository: string|null}
+     */
+    protected function getDefaultConfiguration(): array
+    {
+        return self::DEFAULT_CONFIGURATION;
+    }
+}

--- a/src/Vcs/GithubVcsProvider.php
+++ b/src/Vcs/GithubVcsProvider.php
@@ -68,7 +68,10 @@ final class GithubVcsProvider implements DeployableVcsProviderInterface
     public function __construct(
         private readonly ClientInterface $client,
         private ?string $accessToken = null,
+        // @todo Remove annotations once https://github.com/rectorphp/rector/issues/7568 is resolved
+        /** @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector */
         private ?string $owner = null,
+        /** @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector */
         private ?string $name = null,
         private ?string $environment = null,
     ) {

--- a/src/Vcs/GithubVcsProvider.php
+++ b/src/Vcs/GithubVcsProvider.php
@@ -140,7 +140,9 @@ final class GithubVcsProvider implements DeployableVcsProviderInterface
 
         // Find latest successful deployment
         foreach ($nodes as $node) {
-            if (self::SUCCESSFUL_DEPLOYMENT_STATUS === $node['latestStatus']['state']) {
+            $state = $node['latestStatus']['state'] ?? null;
+
+            if (self::SUCCESSFUL_DEPLOYMENT_STATUS === $state) {
                 return new Asset\Revision\Revision($node['commitOid']);
             }
         }
@@ -196,7 +198,9 @@ final class GithubVcsProvider implements DeployableVcsProviderInterface
         );
 
         foreach ($nodes as $node) {
-            if (in_array($node['latestStatus']['state'], self::ACTIVE_DEPLOYMENT_STATUSES, true)) {
+            $state = $node['latestStatus']['state'] ?? null;
+
+            if (in_array($state, self::ACTIVE_DEPLOYMENT_STATUSES, true)) {
                 $deployments[] = new Dto\Deployment(
                     new Psr7\Uri($node['latestStatus']['logUrl']),
                     new Asset\Revision\Revision($node['commitOid']),

--- a/tests/Build/Stubs/GraphQL/QueryBuilder.stub
+++ b/tests/Build/Stubs/GraphQL/QueryBuilder.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace GraphQL\QueryBuilder;
+
+class QueryBuilder
+{
+    /**
+     * @param string|self $selectedField
+     * @return self
+     */
+    public function selectField($selectedField): self { }
+
+    /**
+     * @param mixed $argumentValue
+     * @return self
+     */
+    public function setArgument(string $argumentName, $argumentValue): self { }
+
+    /**
+     * @param mixed $defaultValue
+     * @return self
+     */
+    public function setVariable(string $name, string $type, bool $isRequired = false, $defaultValue = null): self { }
+}

--- a/tests/Unit/Config/Initialization/Step/VcsConfigStepTest.php
+++ b/tests/Unit/Config/Initialization/Step/VcsConfigStepTest.php
@@ -187,6 +187,50 @@ final class VcsConfigStepTest extends Tests\Unit\ContainerAwareTestCase
     /**
      * @test
      */
+    public function executeAsksForAccessTokenForVcsTypeGithub(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes', Vcs\GithubVcsProvider::getName(), 'foo', 'foo/baz', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'foo',
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['access-token'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Access token', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeAsksForRepositoryForVcsTypeGithub(): void
+    {
+        $input = $this->request->getInput();
+
+        self::assertInstanceOf(Console\Input\StreamableInputInterface::class, $input);
+
+        self::setInputs(['yes', Vcs\GithubVcsProvider::getName(), 'foo', 'foo/baz', ''], $input);
+
+        self::assertTrue($this->subject->execute($this->request));
+        self::assertSame(
+            'foo/baz',
+            $this->request->getConfig()['frontend-assets'][0]['vcs']['repository'],
+        );
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Repository (<owner>/<name>)', $output);
+    }
+
+    /**
+     * @test
+     */
     public function executeShowErrorIfGivenVcsConfigExtraIsNotValidJson(): void
     {
         $input = $this->request->getInput();

--- a/tests/Unit/Vcs/GithubVcsProviderTest.php
+++ b/tests/Unit/Vcs/GithubVcsProviderTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Vcs;
+
+use CPSIT\FrontendAssetHandler\Asset;
+use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Tests;
+use CPSIT\FrontendAssetHandler\Vcs;
+use Generator;
+use GuzzleHttp\Exception as GuzzleException;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message;
+use Throwable;
+
+/**
+ * GithubVcsProviderTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class GithubVcsProviderTest extends TestCase
+{
+    use Tests\Unit\ClientMockTrait;
+
+    private Asset\Definition\Vcs $vcs;
+    private Vcs\GithubVcsProvider $subject;
+
+    protected function setUp(): void
+    {
+        $this->vcs = new Asset\Definition\Vcs([
+            'type' => Vcs\GithubVcsProvider::getName(),
+            'access-token' => 'foo',
+            'repository' => 'foo/baz',
+            'environment' => 'baz',
+        ]);
+        $this->subject = new Vcs\GithubVcsProvider($this->getPreparedClient());
+    }
+
+    /**
+     * @test
+     */
+    public function withVcsThrowsExceptionIfAccessTokenIsMissing(): void
+    {
+        unset($this->vcs['access-token']);
+
+        $this->expectException(Exception\MissingConfigurationException::class);
+        $this->expectExceptionCode(1623867663);
+        $this->expectExceptionMessage('Configuration for key "access-token" is missing or invalid.');
+
+        $this->subject->withVcs($this->vcs);
+    }
+
+    /**
+     * @test
+     */
+    public function withVcsThrowsExceptionIfRepositoryIsMissing(): void
+    {
+        unset($this->vcs['repository']);
+
+        $this->expectException(Exception\MissingConfigurationException::class);
+        $this->expectExceptionCode(1623867663);
+        $this->expectExceptionMessage('Configuration for key "repository" is missing or invalid.');
+
+        $this->subject->withVcs($this->vcs);
+    }
+
+    /**
+     * @test
+     */
+    public function withVcsReturnsClonedInstance(): void
+    {
+        $actual = $this->subject->withVcs($this->vcs);
+
+        self::assertInstanceOf(Vcs\GithubVcsProvider::class, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function getSourceUrlThrowsExceptionIfResponseIsUnexpected(): void
+    {
+        $this->mockHandler->append($response = new Psr7\Response());
+
+        $response->getBody()->write('{"data":"baz"}');
+        $response->getBody()->rewind();
+
+        $this->expectExceptionObject(Exception\InvalidResponseException::create('{"data":"baz"}'));
+
+        $this->subject->withVcs($this->vcs)->getSourceUrl();
+    }
+
+    /**
+     * @test
+     */
+    public function getSourceUrlReturnsSourceUrl(): void
+    {
+        $this->mockHandler->append($response = new Psr7\Response());
+
+        $response->getBody()->write('{"data":{"repository":{"url":"foo"}}}');
+        $response->getBody()->rewind();
+
+        self::assertSame('foo', $this->subject->withVcs($this->vcs)->getSourceUrl());
+    }
+
+    /**
+     * @test
+     */
+    public function getLatestRevisionReturnsNullIfApiResponseIsUnexpected(): void
+    {
+        $this->mockHandler->append(new GuzzleException\TransferException());
+
+        self::assertNull($this->subject->withVcs($this->vcs)->getLatestRevision());
+    }
+
+    /**
+     * @test
+     */
+    public function getLatestRevisionReturnsNullIfApiResponseIsInvalid(): void
+    {
+        $this->mockHandler->append($response = new Psr7\Response());
+
+        $response->getBody()->write('{"data":"foo"}');
+        $response->getBody()->rewind();
+
+        self::assertNull($this->subject->withVcs($this->vcs)->getLatestRevision());
+    }
+
+    /**
+     * @test
+     */
+    public function getLatestRevisionReturnsRevisionForPreConfiguredEnvironment(): void
+    {
+        $this->mockHandler->append($response = new Psr7\Response());
+
+        $response->getBody()->write('{"data":{"repository":{"deployments":{"nodes":[{"latestStatus":{"state":"SUCCESS"},"commitOid":"1234567890"}]}}}}');
+        $response->getBody()->rewind();
+
+        $expected = new Asset\Revision\Revision('1234567890');
+
+        self::assertEquals($expected, $this->subject->withVcs($this->vcs)->getLatestRevision());
+        self::assertStringContainsString('environments: \\"baz\\"', (string) $this->getLastRequest()->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function getLatestRevisionReturnsRevisionForGivenEnvironment(): void
+    {
+        $this->mockHandler->append($response = new Psr7\Response());
+
+        $response->getBody()->write('{"data":{"repository":{"deployments":{"nodes":[{"latestStatus":{"state":"SUCCESS"},"commitOid":"1234567890"}]}}}}');
+        $response->getBody()->rewind();
+
+        $expected = new Asset\Revision\Revision('1234567890');
+
+        self::assertEquals($expected, $this->subject->withVcs($this->vcs)->getLatestRevision('foo'));
+        self::assertStringContainsString('environments: \\"foo\\"', (string) $this->getLastRequest()->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function getLatestRevisionReturnsNullIfNoSuccessfulDeploymentsAreAvailable(): void
+    {
+        $this->mockHandler->append($response = new Psr7\Response());
+
+        $response->getBody()->write('{"data":{"repository":{"deployments":{"nodes":[]}}}}');
+        $response->getBody()->rewind();
+
+        self::assertNull($this->subject->withVcs($this->vcs)->getLatestRevision());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider hasRevisionReturnsTrueIfRevisionExistsInVcsDataProvider
+     */
+    public function hasRevisionReturnsTrueIfRevisionExistsInVcs(
+        Message\ResponseInterface|Throwable $response,
+        bool $expected,
+    ): void {
+        $this->mockHandler->append($response);
+
+        $revision = new Asset\Revision\Revision('1234567890');
+
+        self::assertSame($expected, $this->subject->withVcs($this->vcs)->hasRevision($revision));
+        self::assertStringContainsString(
+            'object(oid: \\"1234567890\\")',
+            (string) $this->getLastRequest()->getBody(),
+        );
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getActiveDeploymentsReturnsActiveDeploymentsIfAnyPipelinesAreActiveDataProvider
+     *
+     * @param list<Vcs\Dto\Deployment> $expected
+     */
+    public function getActiveDeploymentsReturnsActiveDeploymentsIfAnyPipelinesAreActive(
+        Message\ResponseInterface $response,
+        array $expected,
+    ): void {
+        $this->mockHandler->append($response);
+
+        self::assertEquals($expected, $this->subject->withVcs($this->vcs)->getActiveDeployments());
+    }
+
+    /**
+     * @return Generator<string, array{Message\ResponseInterface|Throwable, bool}>
+     */
+    public function hasRevisionReturnsTrueIfRevisionExistsInVcsDataProvider(): Generator
+    {
+        $response = new Psr7\Response();
+        $response->getBody()->write('{"data":{"repository":{"object":"foo"}}}');
+        $response->getBody()->rewind();
+
+        yield 'exception' => [new GuzzleException\TransferException(), false];
+        yield 'unexpected response' => [$response->withStatus(404), false];
+        yield 'valid response' => [$response, true];
+    }
+
+    /**
+     * @return \Generator<string, array{Message\ResponseInterface, list<Vcs\Dto\Deployment>}>
+     */
+    public function getActiveDeploymentsReturnsActiveDeploymentsIfAnyPipelinesAreActiveDataProvider(): Generator
+    {
+        $uri = new Psr7\Uri('https://www.example.com');
+        $revision = new Asset\Revision\Revision('1234567890');
+        $deployment = new Vcs\Dto\Deployment($uri, $revision);
+
+        /**
+         * @param list<string> $statuses
+         */
+        $createResponse = function (array $statuses) use ($deployment): Message\ResponseInterface {
+            $response = new Psr7\Response();
+            $json = [
+                'data' => [
+                    'repository' => [
+                        'deployments' => [
+                            'nodes' => array_map(
+                                fn (string $status) => [
+                                    'latestStatus' => [
+                                        'state' => $status,
+                                        'logUrl' => 'https://www.example.com',
+                                    ],
+                                    'commitOid' => $deployment->getRevision()->get(),
+                                ],
+                                $statuses,
+                            ),
+                        ],
+                    ],
+                ],
+            ];
+
+            $response->getBody()->write(json_encode($json, JSON_THROW_ON_ERROR));
+            $response->getBody()->rewind();
+
+            return $response;
+        };
+
+        yield 'pending deployment' => [$createResponse(['PENDING']), [$deployment]];
+        yield 'queued deployment' => [$createResponse(['QUEUED']), [$deployment]];
+        yield 'active deployment' => [$createResponse(['IN_PROGRESS']), [$deployment]];
+        yield 'waiting deployment' => [$createResponse(['WAITING']), [$deployment]];
+        yield 'multiple deployments' => [$createResponse(['PENDING', 'QUEUED', 'IN_PROGRESS', 'WAITING']), [$deployment, $deployment, $deployment, $deployment]];
+        yield 'no active deployments' => [$createResponse([]), []];
+    }
+}


### PR DESCRIPTION
This PR adds a new VCS provider `github`. It requires the following configuration:

- `access-token` with token scope `repo`
- `repository` in the format `<owner>/<name>`, e.g. `CPS-IT/frontend-asset-handler`