### PR TITLE
[BUGFIX] Harden match for environment mapping branches

### DIFF
--- a/src/Asset/Environment/Map/Pair.php
+++ b/src/Asset/Environment/Map/Pair.php
@@ -73,6 +73,6 @@ final class Pair
 
     private function matches(string $input): bool
     {
-        return fnmatch($this->inputPattern, $input);
+        return fnmatch($this->inputPattern, $input, FNM_PATHNAME);
     }
 }

--- a/tests/Unit/Asset/Environment/EnvironmentResolverTest.php
+++ b/tests/Unit/Asset/Environment/EnvironmentResolverTest.php
@@ -64,6 +64,7 @@ final class EnvironmentResolverTest extends TestCase
         self::assertSame('preview', $this->subject->resolve('preview'));
         self::assertSame('integration', $this->subject->resolve('integration'));
         self::assertSame('1.0.0', $this->subject->resolve('1.0.0'));
+        self::assertSame(Environment::Stable->value, $this->subject->resolve('test/foo.foo.foo'));
     }
 
     /**


### PR DESCRIPTION
It was discovered that the current implementation to detect matching branches is not strong enough. The version pattern `*.*.*` matches on all branches, therefore the default value "stable" is never considered.