### PR TITLE
[FEATURE] lower error level to warning for already downloaded revisions

### DIFF
--- a/src/Command/FetchAssetsCommand.php
+++ b/src/Command/FetchAssetsCommand.php
@@ -45,6 +45,8 @@ final class FetchAssetsCommand extends BaseAssetsCommand
     private const SUCCESSFUL = 0;
     private const ERRONEOUS = 1;
 
+    private bool $hasWarnings = false;
+
     private Console\Style\SymfonyStyle $io;
 
     public function __construct(
@@ -156,9 +158,13 @@ final class FetchAssetsCommand extends BaseAssetsCommand
         }
 
         if (!$successful && $assetCount > 1) {
-            $this->io->warning('Command finished with errors.');
+            $this->io->warning(sprintf('Command finished with errors%s.', $this->hasWarnings ? ' and warnings' : ''));
 
             return self::ERRONEOUS;
+        }
+
+        if ($this->hasWarnings) {
+            $this->io->warning('Command finished with warnings.');
         }
 
         return self::SUCCESSFUL;
@@ -188,6 +194,7 @@ final class FetchAssetsCommand extends BaseAssetsCommand
         }
 
         if ($asset instanceof Asset\ExistingAsset) {
+            $this->hasWarnings = true;
             $this->io->warning(
                 sprintf(
                     'Assets%s are already downloaded. Use -f to re-download them.',

--- a/src/Command/FetchAssetsCommand.php
+++ b/src/Command/FetchAssetsCommand.php
@@ -188,14 +188,14 @@ final class FetchAssetsCommand extends BaseAssetsCommand
         }
 
         if ($asset instanceof Asset\ExistingAsset) {
-            $this->io->error(
+            $this->io->warning(
                 sprintf(
                     'Assets%s are already downloaded. Use -f to re-download them.',
                     null !== $asset->getRevision() ? ' of revision '.$asset->getRevision()->getShort() : ''
                 )
             );
 
-            return false;
+            return true;
         }
 
         if (!($asset instanceof Asset\ProcessedAsset)) {

--- a/tests/Unit/Command/FetchAssetsCommandTest.php
+++ b/tests/Unit/Command/FetchAssetsCommandTest.php
@@ -158,7 +158,7 @@ final class FetchAssetsCommandTest extends Tests\Unit\CommandTesterAwareTestCase
         );
         $output = $this->commandTester->getDisplay();
 
-        self::assertSame(1, $exitCode);
+        self::assertSame(0, $exitCode);
         self::assertStringContainsString(
             'Assets of revision 1234567 are already downloaded. Use -f to re-download them.',
             $output,


### PR DESCRIPTION
## What is changing?
This PR changes the output for already existing revisions in the `FetchAssetsCommand` console command. No further configuration is required.

## Why is this change proposed?
It is this author's humble opinion that it should not be an error when a revision was previously downloaded and won't be re-downloaded hence. However, while agreeing that a success message would encourage users to draw a wrong conclusion a `warning` level is suggested. Consistently, no error is printed at the end of (potentially) all fetch attempts. The suggestion to use the `-f` parameter to enforce a re-download is kept. 