### PR TITLE
[BUGFIX] fix duplicate test assertion

### DIFF
--- a/src/Command/FetchAssetsCommand.php
+++ b/src/Command/FetchAssetsCommand.php
@@ -204,7 +204,7 @@ final class FetchAssetsCommand extends BaseAssetsCommand
             return false;
         }
 
-        $this->io->success(sprintf('Assets successfully downloaded to %s', $asset->getProcessedTargetPath()));
+        $this->io->success(sprintf('Assets successfully downloaded to %s.', $asset->getProcessedTargetPath()));
 
         return true;
     }

--- a/tests/Unit/Command/FetchAssetsCommandTest.php
+++ b/tests/Unit/Command/FetchAssetsCommandTest.php
@@ -105,7 +105,7 @@ final class FetchAssetsCommandTest extends Tests\Unit\CommandTesterAwareTestCase
         $output = $this->commandTester->getDisplay();
 
         self::assertSame(1, $exitCode);
-        self::assertStringContainsString('An error occurred while downloading "foo" to "baz".', $output);
+        self::assertStringContainsString('Assets successfully downloaded to foo.', $output);
         self::assertStringContainsString('An error occurred while downloading "foo" to "baz".', $output);
         self::assertStringContainsString('Command finished with errors.', $output);
     }
@@ -132,7 +132,7 @@ final class FetchAssetsCommandTest extends Tests\Unit\CommandTesterAwareTestCase
 
         self::assertSame(0, $exitCode);
         self::assertStringContainsString('Error while fetching assets, falling back to latest assets.', $output);
-        self::assertStringContainsString('Assets successfully downloaded to foo', $output);
+        self::assertStringContainsString('Assets successfully downloaded to foo.', $output);
     }
 
     /**
@@ -213,7 +213,7 @@ final class FetchAssetsCommandTest extends Tests\Unit\CommandTesterAwareTestCase
         self::assertStringContainsString('Asset environment: stable', $output);
         self::assertStringContainsString('Processing of asset definition #1', $output);
         self::assertStringContainsString('Processing of asset definition #2', $output);
-        self::assertStringContainsString('Assets successfully downloaded to foo', $output);
+        self::assertStringContainsString('Assets successfully downloaded to foo.', $output);
     }
 
     /**
@@ -239,7 +239,7 @@ final class FetchAssetsCommandTest extends Tests\Unit\CommandTesterAwareTestCase
         self::assertStringContainsString('Asset environment: stable', $output);
         self::assertStringContainsString('Processing of asset definition #1', $output);
         self::assertStringContainsString('Processing of asset definition #2', $output);
-        self::assertStringContainsString('Assets successfully downloaded to foo', $output);
+        self::assertStringContainsString('Assets successfully downloaded to foo.', $output);
     }
 
     protected static function getCoveredCommand(): string


### PR DESCRIPTION
A duplicate assertion in `FetchAssetsCommandTest` is fixed to catch a successful case:

https://github.com/CPS-IT/frontend-asset-handler/blob/a4fcc69069950ce0c8325171fd8b37d95f9c0c83/tests/Unit/Command/FetchAssetsCommandTest.php#L108-L109