### PR TITLE
[BUGFIX] Add mapping for Renovate branches to default map

### DIFF
--- a/docs/config/environments.md
+++ b/docs/config/environments.md
@@ -71,6 +71,7 @@ resolves to the following mapping table:
 | `feature/*`                        | `fe-{slug}`                      | –        |
 | `preview`                          | `preview`                        | –        |
 | `integration`                      | `integration`                    | –        |
+| `renovate/*`                       | `latest`                         | –        |
 | `/^v?\d+\.\d+\.\d+$/`<sup>1)</sup> | `{branch}`<sup>1)</sup>          | –        |
 
 _<sup>1)</sup> If a specific version number is given, then exactly this version number is

--- a/src/Asset/Environment/Map/MapFactory.php
+++ b/src/Asset/Environment/Map/MapFactory.php
@@ -70,6 +70,7 @@ final class MapFactory
             new Pair('feature/*', new SlugTransformer('fe-{slug}')),
             new Pair('preview', $passthroughTransformer),
             new Pair('integration', $passthroughTransformer),
+            new Pair('renovate/*', $latestTransformer),
             new Pair(self::REGEX_PATTERN_VERSION, $passthroughTransformer),
         ]);
     }

--- a/tests/Unit/Asset/Environment/Map/MapFactoryTest.php
+++ b/tests/Unit/Asset/Environment/Map/MapFactoryTest.php
@@ -191,15 +191,18 @@ final class MapFactoryTest extends ContainerAwareTestCase
      */
     public function createDefaultReturnsDefaultMapDataProvider(): Generator
     {
+        $latestTransformer = new StaticTransformer(Environment::Latest->value);
+        $passthroughTransformer = new PassthroughTransformer();
         $defaultMap = fn (TransformerInterface $stableTransformer): Map => new Map([
             new Pair('main', $stableTransformer),
             new Pair('master', $stableTransformer),
-            new Pair('develop', new StaticTransformer(Environment::Latest->value)),
-            new Pair('release/*', new StaticTransformer(Environment::Latest->value)),
+            new Pair('develop', $latestTransformer),
+            new Pair('release/*', $latestTransformer),
             new Pair('feature/*', new SlugTransformer('fe-{slug}')),
-            new Pair('preview', new PassthroughTransformer()),
-            new Pair('integration', new PassthroughTransformer()),
-            new Pair('/^v?\\d+\\.\\d+\\.\\d+$/', new PassthroughTransformer()),
+            new Pair('preview', $passthroughTransformer),
+            new Pair('integration', $passthroughTransformer),
+            new Pair('renovate/*', $latestTransformer),
+            new Pair('/^v?\\d+\\.\\d+\\.\\d+$/', $passthroughTransformer),
         ]);
 
         yield 'no version' => [null, $defaultMap(new StaticTransformer(Environment::Stable->value))];


### PR DESCRIPTION
This PR adds a new mapping for all `renovate/*` branches, defaulting to the `latest` environment. This avoids failing CI for automated dependency updates with Renovate.