### PR TITLE
[BUGFIX] Pass on strategy when fetching assets for fallback environment

### DIFF
--- a/src/Command/FetchAssetsCommand.php
+++ b/src/Command/FetchAssetsCommand.php
@@ -190,7 +190,7 @@ final class FetchAssetsCommand extends BaseAssetsCommand
 
             $source['environment'] = Asset\Environment\Environment::Latest->value;
 
-            return $this->performAssetHandling($handler, $source, $target);
+            return $this->performAssetHandling($handler, $source, $target, $strategy);
         }
 
         if ($asset instanceof Asset\ExistingAsset) {

--- a/tests/Unit/Fixtures/Classes/DummyHandler.php
+++ b/tests/Unit/Fixtures/Classes/DummyHandler.php
@@ -48,6 +48,7 @@ final class DummyHandler implements Handler\HandlerInterface, ChattyInterface
      * @var list<Throwable|Asset\Asset>
      */
     public array $returnQueue = [];
+    public ?Strategy\Strategy $lastStrategy = null;
 
     public static function getName(): string
     {
@@ -59,6 +60,8 @@ final class DummyHandler implements Handler\HandlerInterface, ChattyInterface
         Asset\Definition\Target $target,
         Strategy\Strategy $strategy = null,
     ): Asset\Asset {
+        $this->lastStrategy = $strategy;
+
         $nextReturn = array_shift($this->returnQueue);
 
         if ($nextReturn instanceof Throwable) {


### PR DESCRIPTION
The selected strategy is currently not passed on if the `fetch` command is executed together with `--failsafe` and the requested download fails. This is now fixed and the strategy is always passed to the next iteration.