### PR TITLE
[BUGFIX] Exclude various dev-only files from being exported

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *                       text=auto
+/.ddev                  export-ignore
 /.github                export-ignore
 /tests                  export-ignore
 /.editorconfig          export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *                       text=auto
 /.ddev                  export-ignore
 /.github                export-ignore
+/config/services_test.* export-ignore
 /tests                  export-ignore
 /.editorconfig          export-ignore
 /.gitattributes         export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 /box.json               export-ignore
 /codecov.yml            export-ignore
 /composer.lock          export-ignore
+/CONTRIBUTING.md        export-ignore
 /phpstan.neon           export-ignore
 /phpunit.coverage.xml   export-ignore
 /phpunit.xml            export-ignore


### PR DESCRIPTION
The following files and directories will no longer be exported:

* `.ddev` directory
* `config/services_test.*` files
* `CONTRIBUTING.md` file