### PR TITLE
[BUGFIX] Assure public API classes are publicly available services

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,9 +29,19 @@ services:
     CPSIT\FrontendAssetHandler\Asset\Environment\Transformer\TransformerInterface:
       autowire: false
 
+  CPSIT\FrontendAssetHandler\Asset\Definition\AssetDefinitionFactory:
+    public: true
+
   CPSIT\FrontendAssetHandler\Asset\Environment\Map\MapFactory:
+    public: true
     arguments:
       $transformers: '%asset_environment.transformers%'
+
+  CPSIT\FrontendAssetHandler\Config\ConfigFacade:
+    public: true
+    arguments:
+      $loaders: !tagged_iterator config.loader
+      $writers: !tagged_iterator config.writer
 
   CPSIT\FrontendAssetHandler\Config\Initialization\Step\HandlerConfigStep:
     arguments:
@@ -57,12 +67,6 @@ services:
         - '@CPSIT\FrontendAssetHandler\Config\Initialization\Step\TargetConfigStep'
         - '@CPSIT\FrontendAssetHandler\Config\Initialization\Step\HandlerConfigStep'
         - '@CPSIT\FrontendAssetHandler\Config\Initialization\Step\VcsConfigStep'
-
-  CPSIT\FrontendAssetHandler\Config\ConfigFacade:
-    public: true
-    arguments:
-      $loaders: !tagged_iterator config.loader
-      $writers: !tagged_iterator config.writer
 
   CPSIT\FrontendAssetHandler\Handler\HandlerFactory:
     public: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -59,6 +59,9 @@ services:
     arguments:
       $vcsProviders: !tagged_locator { tag: 'asset_handling.vcs_provider', default_index_method: 'getName' }
 
+  CPSIT\FrontendAssetHandler\Config\Parser\Parser:
+    public: true
+
   CPSIT\FrontendAssetHandler\Command\InitConfigCommand:
     arguments:
       $initSteps:


### PR DESCRIPTION
Factories are part of the public API and therefore must be publicly accessible. All internal factories are still private. Additionally, the config parser (which is part of the public API as well) is now a public service.