### PR TITLE
[BUGFIX] Streamline base path handling for relative paths

### DIFF
--- a/docs/config/target.md
+++ b/docs/config/target.md
@@ -15,8 +15,9 @@ be a valid identifier that is specified in the map provided by
 
 ### `path`
 
-Path where to extract fetched assets. This can be an absolute path or a path relative
-to the current working directory.
+Path where to extract fetched assets. This can be either an absolute path or a path
+relative to the path of your project's `composer.json` or the current working
+directory (when executing the library as PHAR file).
 
 * Required: **yes**
 * Default: **–**

--- a/src/Config/ConfigFacade.php
+++ b/src/Config/ConfigFacade.php
@@ -48,7 +48,7 @@ final class ConfigFacade
 
     public function load(string $file): Config
     {
-        $filePath = Helper\FilesystemHelper::resolveRelativePath($file, true);
+        $filePath = Helper\FilesystemHelper::resolveRelativePath($file);
 
         foreach ($this->loaders as $loader) {
             if ($loader::canLoad($filePath)) {

--- a/src/Config/Initialization/Step/ConfigFileStep.php
+++ b/src/Config/Initialization/Step/ConfigFileStep.php
@@ -106,7 +106,7 @@ final class ConfigFileStep extends BaseStep implements InteractiveStepInterface
             $this->output,
             new Console\Question\Question('<info>Path to the new config file</info>: '),
         );
-        $request->setConfigFile(Helper\FilesystemHelper::resolveRelativePath($configFile, true));
+        $request->setConfigFile(Helper\FilesystemHelper::resolveRelativePath($configFile));
         $request->setConfig(new Config\Config([], $request->getConfigFile()));
         $request->setOption('definition-id', 0);
 

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -51,7 +51,7 @@ final class ContainerFactory
         bool $debug = null,
         private readonly bool $includeTestSources = false,
     ) {
-        $this->configFile = $configFile ? Helper\FilesystemHelper::resolveRelativePath($configFile, true) : null;
+        $this->configFile = $configFile ? Helper\FilesystemHelper::resolveRelativePath($configFile) : null;
         $this->cache = new Cache\ContainerCache($this->configFile, $this->includeTestSources, $debug);
         $this->configLoader = new Config\Loader\ExternalJsonFileLoader();
         $this->servicesParser = new Config\Parser\ServicesParser();

--- a/src/Helper/FilesystemHelper.php
+++ b/src/Helper/FilesystemHelper.php
@@ -27,6 +27,7 @@ use Composer\InstalledVersions;
 use CPSIT\FrontendAssetHandler\Exception;
 use Ergebnis\Json\Normalizer;
 use OutOfBoundsException;
+use Phar;
 use Symfony\Component\Filesystem;
 
 use function getcwd;
@@ -60,7 +61,7 @@ final class FilesystemHelper
         return Filesystem\Path::canonicalize($projectDirectory);
     }
 
-    public static function resolveRelativePath(string $relativePath, bool $relativeToWorkingDirectory = false): string
+    public static function resolveRelativePath(string $relativePath): string
     {
         $filesystem = new Filesystem\Filesystem();
 
@@ -68,7 +69,11 @@ final class FilesystemHelper
             return $relativePath;
         }
 
-        $basePath = $relativeToWorkingDirectory ? getcwd() : self::getProjectDirectory();
+        if (Phar::running()) {
+            $basePath = getcwd();
+        } else {
+            $basePath = InstalledVersions::getRootPackage()['install_path'];
+        }
 
         // @codeCoverageIgnoreStart
         if (false === $basePath) {

--- a/src/Traits/TargetPathBuilderTrait.php
+++ b/src/Traits/TargetPathBuilderTrait.php
@@ -46,6 +46,6 @@ trait TargetPathBuilderTrait
         }
 
         // Prefix target path with current working directory
-        return FilesystemHelper::resolveRelativePath($targetPath, true);
+        return FilesystemHelper::resolveRelativePath($targetPath);
     }
 }

--- a/tests/Unit/Helper/FilesystemHelperTest.php
+++ b/tests/Unit/Helper/FilesystemHelperTest.php
@@ -26,12 +26,10 @@ namespace CPSIT\FrontendAssetHandler\Tests\Unit\Helper;
 use CPSIT\FrontendAssetHandler\Exception;
 use CPSIT\FrontendAssetHandler\Helper;
 use Ergebnis\Json\Normalizer;
-use Generator;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function dirname;
-use function getcwd;
 
 /**
  * FilesystemHelperTest.
@@ -53,15 +51,23 @@ final class FilesystemHelperTest extends TestCase
 
     /**
      * @test
-     *
-     * @dataProvider resolveRelativePathMakesRelativePathAbsoluteDataProvider
      */
-    public function resolveRelativePathMakesRelativePathAbsolute(
-        string $path,
-        bool $relativeToWorkingDirectory,
-        string $expected,
-    ): void {
-        self::assertSame($expected, Helper\FilesystemHelper::resolveRelativePath($path, $relativeToWorkingDirectory));
+    public function resolveRelativePathReturnsGivenPathIfItIsAnAbsolutePath(): void
+    {
+        $path = '/foo/baz';
+
+        self::assertSame($path, Helper\FilesystemHelper::resolveRelativePath($path));
+    }
+
+    /**
+     * @test
+     */
+    public function resolveRelativePathMakesRelativePathAbsolute(): void
+    {
+        $path = 'foo';
+        $expected = dirname(__DIR__, 3).'/foo';
+
+        self::assertSame($expected, Helper\FilesystemHelper::resolveRelativePath($path));
     }
 
     /**
@@ -102,15 +108,5 @@ final class FilesystemHelperTest extends TestCase
         self::assertInstanceOf(Normalizer\Json::class, $actual);
         self::assertEquals($expected, $actual->decoded());
         self::assertJsonStringEqualsJsonString('{"foo":"baz"}', $actual->encoded());
-    }
-
-    /**
-     * @return Generator<string, array{string, bool, string}>
-     */
-    public function resolveRelativePathMakesRelativePathAbsoluteDataProvider(): Generator
-    {
-        yield 'absolute path' => ['/foo/baz', false, '/foo/baz'];
-        yield 'relative path' => ['foo', false, dirname(__DIR__, 3).'/foo'];
-        yield 'relative path to working directory' => ['foo', true, getcwd().'/foo'];
     }
 }


### PR DESCRIPTION
When relative paths are passed and resolved using `FilesystemHelper::resolveRelativePath()`, the base path determination logic was currently not always equal. Sometimes, the current working directory was used, whereas other code parts used the project root path.

In order to streamline the logic, the path of a project's `composer.json` is now always used as base path, unless the current execution context is a running PHAR file. In this case, the current working directory is still used as fallback.