### PR TITLE
[TASK] Enable Dependabot auto-merge for minor and patch updates

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,15 @@
+name: Dependabot auto-merge
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  dependabot-auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.MERGE_TOKEN }}


### PR DESCRIPTION
This PR enables auto-merge for minor and patch updates raised by Dependabot, reducing the maintenance effort significantly.