### PR TITLE
[BUGFIX] Promote all properties in `GitlabVcsProvider`

### DIFF
--- a/src/Vcs/GitlabVcsProvider.php
+++ b/src/Vcs/GitlabVcsProvider.php
@@ -59,14 +59,15 @@ final class GitlabVcsProvider implements DeployableVcsProviderInterface
     ];
 
     private Message\UriInterface $baseUrl;
-    private ?string $accessToken = null;
-    private ?int $projectId = null;
-    private ?string $environment = null;
 
     public function __construct(
         private readonly ClientInterface $client,
+        string $baseUrl = null,
+        private ?string $accessToken = null,
+        private ?int $projectId = null,
+        private ?string $environment = null,
     ) {
-        $this->createBaseUrl(self::DEFAULT_BASE_URL);
+        $this->baseUrl = $this->createBaseUrl($baseUrl ?? self::DEFAULT_BASE_URL);
     }
 
     /**


### PR DESCRIPTION
VCS providers are designed to work either on a standalone basis or by construction from a valid `Vcs` object. Therefore, all available properties must be settable for both construction strategies. Since this was not available for the standalone strategy in `GitlabVcsProvider`, all properties are now promoted via the class constructor.