### PR TITLE
[TASK] Revert "[BUGFIX] Disable invalid behavior of ReadOnlyPropertyRector"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"phpstan/phpstan-symfony": "^1.1",
 		"phpstan/phpstan-webmozart-assert": "^1.2",
 		"phpunit/phpunit": "^9.5.5",
-		"rector/rector": "^0.14.0"
+		"rector/rector": "^0.14.7"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0113acaeea5316f12f153a0b3f759e0",
+    "content-hash": "f31f1da7a77ab93782234089f2bc4b20",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",

--- a/src/Vcs/GithubVcsProvider.php
+++ b/src/Vcs/GithubVcsProvider.php
@@ -68,10 +68,7 @@ final class GithubVcsProvider implements DeployableVcsProviderInterface
     public function __construct(
         private readonly ClientInterface $client,
         private ?string $accessToken = null,
-        // @todo Remove annotations once https://github.com/rectorphp/rector/issues/7568 is resolved
-        /** @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector */
         private ?string $owner = null,
-        /** @noRector \Rector\Php81\Rector\Property\ReadOnlyPropertyRector */
         private ?string $name = null,
         private ?string $environment = null,
     ) {


### PR DESCRIPTION
This reverts commit 9f03ae874ead18a3bdf193baa225343b244bddf0 and requires at least Rector 0.14.7 which fixed the mentioned bug with rectorphp/rector-src#3030.