### PR TITLE
[TASK] Do not ignore platform reqs for PHP 8.2 in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,9 +17,6 @@ jobs:
       matrix:
         php-version: ["8.1", "8.2"]
         dependencies: ["locked", "highest", "lowest"]
-        include:
-          - php-version: "8.2"
-            composer-options: "--ignore-platform-req=php+"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,7 +35,6 @@ jobs:
         uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
-          composer-options: ${{ matrix.composer-options }}
 
       # Run tests
       - name: Run tests


### PR DESCRIPTION
The dependencies for PHP 8.2 are quite stable, so there's no more need to ignore platform requirements.