### PR TITLE
[FEATURE] Introduce local file provider

### DIFF
--- a/docs/components/providers.md
+++ b/docs/components/providers.md
@@ -21,10 +21,11 @@ It supports the following additional configuration:
 
 ### `command`
 
-Additional command that is locally executed prior to validating the source file.
-It can be used to prepare the source file for further processing with a supported
-[processor](processors.md). When omitted, the source file is expected to exist
-without further modification.
+A custom command that is locally executed prior to validating the source file.
+By default, the source path – as specified in the [url](#url) section – will
+be taken for further processing with a supported processor. However, if you
+first need to prepare such a file or directory, you may define an additional
+custom command here.
 
 * Required: **no**
 * Default: **–**
@@ -44,5 +45,24 @@ the following special placeholders:
 * `{cwd}` is replaced by the current working directory
 * `{temp}` is replaced by a temporary filename (must be at the beginning of the path,
   e.g. `{temp}.tar.gz`)
+
+**Example configuration:**
+
+```json
+{
+    "frontend-assets": [
+        {
+            "source": {
+                "type": "local",
+                "command": "tar -czvf '{url}' -C '{cwd}/frontend' 'dist'",
+                "url": "{temp}.tar.gz"
+            },
+            "target": {
+                // ...
+            }
+        }
+    ]
+}
+```
 
 > :warning: The resolved URL must be an existing path on the local filesystem.

--- a/docs/components/providers.md
+++ b/docs/components/providers.md
@@ -8,3 +8,41 @@ further. The Provider also requests the revision of the requested assets and add
 to the requested [source](../config/source.md).
 
 It supports no additional configuration.
+
+## [`LocalPathProvider`](../../src/Provider/LocalPathProvider.php)
+
+With this Provider, local paths may be used as Frontend asset source. An additional
+command can be specified that is executed prior to validating the local path, e.g.
+to initialize a new build or archive a list of files and directories.
+
+> :bulb: The local path itself is configured by the [`url`](#url) configuration.
+
+It supports the following additional configuration:
+
+### `command`
+
+Additional command that is locally executed prior to validating the source file.
+It can be used to prepare the source file for further processing with a supported
+[processor](processors.md). When omitted, the source file is expected to exist
+without further modification.
+
+* Required: **no**
+* Default: **–**
+
+It may contain placeholders in the form `{<config key>}` that are replaced by source
+configuration values. e.g. `{environment}`. In addition, it supports the following
+special placeholders:
+
+* `{cwd}` is replaced by the current working directory
+* `{url}` is replaced by the resolved [source path (`url`)](#url)
+
+### `url`
+
+In addition to the [default configuration](../config/source.md#url), it may contain
+the following special placeholders:
+
+* `{cwd}` is replaced by the current working directory
+* `{temp}` is replaced by a temporary filename (must be at the beginning of the path,
+  e.g. `{temp}.tar.gz`)
+
+> :warning: The resolved URL must be an existing path on the local filesystem.

--- a/resources/configuration.schema.json
+++ b/resources/configuration.schema.json
@@ -72,6 +72,11 @@
 					"type": "string",
 					"title": "Asset source revision URL",
 					"description": "An URL representing the revision of a remote asset source for a concrete Frontend asset."
+				},
+				"command": {
+					"type": "string",
+					"title": "Asset source generation command",
+					"description": "An optional command to generate a local asset source for a concrete Frontend asset (`{root}` will be replaced by the project root directory)."
 				}
 			},
 			"additionalProperties": true

--- a/src/Asset/Definition/Source.php
+++ b/src/Asset/Definition/Source.php
@@ -65,4 +65,9 @@ class Source extends AssetDefinition
     {
         return $this['revision'];
     }
+
+    public function getCommand(): ?string
+    {
+        return $this['command'];
+    }
 }

--- a/src/Config/Initialization/Step/BaseStep.php
+++ b/src/Config/Initialization/Step/BaseStep.php
@@ -135,7 +135,7 @@ abstract class BaseStep implements StepInterface, ChattyInterface
 
         $placeholders = array_diff(
             Helper\StringHelper::extractPlaceholders($string),
-            ['environment', 'revision'],
+            ['environment', 'revision', 'temp', 'cwd'],
             array_keys($request->getOptions()),
             array_keys($additionalVariables),
         );

--- a/src/Exception/FilesystemFailureException.php
+++ b/src/Exception/FilesystemFailureException.php
@@ -26,6 +26,8 @@ namespace CPSIT\FrontendAssetHandler\Exception;
 use RuntimeException;
 use Throwable;
 
+use function sprintf;
+
 /**
  * FilesystemFailureException.
  *
@@ -49,6 +51,11 @@ final class FilesystemFailureException extends RuntimeException
         return new self(sprintf('The path "%s" was expected to exist, but it does not.', $path), 1624633845);
     }
 
+    public static function forInvalidFile(string $path): self
+    {
+        return new self(sprintf('The file "%s" is invalid or not supported.', $path), 1670866771);
+    }
+
     public static function forInvalidFileContents(string $path): self
     {
         return new self(sprintf('The contents of file "%s" are invalid.', $path), 1627923069);
@@ -57,6 +64,11 @@ final class FilesystemFailureException extends RuntimeException
     public static function forFailedWriteOperation(string $path): self
     {
         return new self(sprintf('An error occurred when writing file contents to "%s".', $path), 1639415423);
+    }
+
+    public static function forFailedCommandExecution(string $command): self
+    {
+        return new self(sprintf('An error occurred while executing "%s".', $command), 1670866484);
     }
 
     public static function forUnresolvableProjectDirectory(): self

--- a/src/Provider/LocalPathProvider.php
+++ b/src/Provider/LocalPathProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Provider;
+
+use CPSIT\FrontendAssetHandler\Asset;
+use CPSIT\FrontendAssetHandler\ChattyInterface;
+use CPSIT\FrontendAssetHandler\Exception;
+use CPSIT\FrontendAssetHandler\Helper;
+use CPSIT\FrontendAssetHandler\Traits;
+use Symfony\Component\Filesystem;
+use Symfony\Component\Process;
+
+use function str_starts_with;
+
+/**
+ * LocalPathProvider.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class LocalPathProvider implements ProviderInterface, ChattyInterface
+{
+    use Traits\OutputAwareTrait;
+
+    public function __construct(
+        private readonly Filesystem\Filesystem $filesystem,
+    ) {
+    }
+
+    public static function getName(): string
+    {
+        return 'local';
+    }
+
+    public function fetchAsset(Asset\Definition\Source $source): Asset\Asset
+    {
+        $url = $this->getAssetUrl($source);
+
+        // Generate asset source
+        if (null !== $source->getCommand()) {
+            $config = $source->getConfig();
+            $config['cwd'] = Helper\FilesystemHelper::getWorkingDirectory();
+            $config['url'] = $url;
+
+            $command = Helper\StringHelper::interpolate($source->getCommand(), $config);
+
+            $this->generateSourceFile($command);
+        }
+
+        // Check if file exists
+        if (!$this->isValidFile($url)) {
+            throw Exception\FilesystemFailureException::forInvalidFile($url);
+        }
+
+        return new Asset\TemporaryAsset($source, $url);
+    }
+
+    public function getAssetUrl(Asset\Definition\Source $source): string
+    {
+        if (null === $source->getUrl()) {
+            throw Exception\MissingConfigurationException::forKey('source/url');
+        }
+
+        $config = $source->getConfig();
+        $config['cwd'] = Helper\FilesystemHelper::getWorkingDirectory();
+
+        // Create temporary filename as placeholder
+        if (str_starts_with($source->getUrl(), '{temp}')) {
+            $config['temp'] = Helper\FilesystemHelper::createTemporaryFile(filenameOnly: true);
+        }
+
+        $url = Helper\StringHelper::interpolate($source->getUrl(), $config);
+
+        return Helper\FilesystemHelper::resolveRelativePath($url);
+    }
+
+    private function generateSourceFile(string $command): void
+    {
+        $progress = $this->output->startProgress('Generating source file...');
+
+        // Run command
+        $process = Process\Process::fromShellCommandline($command);
+        $process->run();
+
+        // Early return if command fails
+        if (!$process->isSuccessful()) {
+            $progress->fail();
+
+            $this->output->writeln($process->getErrorOutput());
+
+            throw Exception\FilesystemFailureException::forFailedCommandExecution($command);
+        }
+
+        $progress->finish();
+    }
+
+    private function isValidFile(string $file): bool
+    {
+        return Filesystem\Path::isLocal($file) && $this->filesystem->exists($file);
+    }
+}

--- a/tests/Unit/Provider/LocalPathProviderTest.php
+++ b/tests/Unit/Provider/LocalPathProviderTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/frontend-asset-handler".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Provider;
+
+use CPSIT\FrontendAssetHandler\Asset\Definition\Source;
+use CPSIT\FrontendAssetHandler\Asset\TemporaryAsset;
+use CPSIT\FrontendAssetHandler\Exception\FilesystemFailureException;
+use CPSIT\FrontendAssetHandler\Exception\MissingConfigurationException;
+use CPSIT\FrontendAssetHandler\Helper\FilesystemHelper;
+use CPSIT\FrontendAssetHandler\Provider\LocalPathProvider;
+use CPSIT\FrontendAssetHandler\Tests\Unit\BufferedConsoleOutput;
+use CPSIT\FrontendAssetHandler\Tests\Unit\ContainerAwareTestCase;
+use Exception;
+use Symfony\Component\Filesystem\Filesystem;
+
+use function realpath;
+use function sprintf;
+use function sys_get_temp_dir;
+
+/**
+ * LocalPathProviderTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class LocalPathProviderTest extends ContainerAwareTestCase
+{
+    private Source $source;
+    private BufferedConsoleOutput $output;
+    private LocalPathProvider $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->source = new Source([
+            'url' => '{temp}.tar.gz',
+            'command' => 'tar -czf "{url}" -C "{cwd}/tests/Unit/Fixtures" "AssetFiles"',
+        ]);
+        $this->output = new BufferedConsoleOutput();
+        $this->subject = new LocalPathProvider($this->container->get(Filesystem::class));
+        $this->subject->setOutput($this->output);
+    }
+
+    /**
+     * @test
+     */
+    public function fetchAssetRunsConfiguredCommandToGenerateAssetSourceFile(): void
+    {
+        $actual = $this->subject->fetchAsset($this->source);
+
+        self::assertInstanceOf(TemporaryAsset::class, $actual);
+        self::assertFileExists($actual->getTempFile());
+        self::assertArchiveHasChild('AssetFiles/assets_0.zip', $actual->getTempFile());
+        self::assertArchiveHasChild('AssetFiles/assets_1.tar', $actual->getTempFile());
+        self::assertArchiveHasChild('AssetFiles/assets_2.tar.gz', $actual->getTempFile());
+        self::assertArchiveHasChild('AssetFiles/revision.txt', $actual->getTempFile());
+    }
+
+    /**
+     * @test
+     */
+    public function fetchAssetThrowsExceptionIfConfiguredCommandCannotBeExecutedSuccessfully(): void
+    {
+        $this->source['command'] = 'foo baz';
+
+        $this->expectExceptionObject(FilesystemFailureException::forFailedCommandExecution('foo baz'));
+
+        try {
+            $this->subject->fetchAsset($this->source);
+        } catch (Exception $exception) {
+            self::assertMatchesRegularExpression('/foo: (command )?not found/', $this->output->fetch());
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function fetchAssetThrowsExceptionIfSourceFileDoesNotExist(): void
+    {
+        unset($this->source['command']);
+
+        $this->expectException(FilesystemFailureException::class);
+        $this->expectExceptionMessageMatches('/^The file "[^"]+" is invalid or not supported\\.$/');
+        $this->expectExceptionCode(1670866771);
+
+        $this->subject->fetchAsset($this->source);
+    }
+
+    /**
+     * @test
+     */
+    public function fetchAssetReturnsTemporaryAsset(): void
+    {
+        $actual = $this->subject->fetchAsset($this->source);
+
+        self::assertInstanceOf(TemporaryAsset::class, $actual);
+        self::assertFileExists($actual->getTempFile());
+    }
+
+    /**
+     * @test
+     */
+    public function getAssetUrlThrowsExceptionIfSourceUrlIsNotConfigured(): void
+    {
+        unset($this->source['url']);
+
+        $this->expectExceptionObject(MissingConfigurationException::forKey('source/url'));
+
+        $this->subject->getAssetUrl($this->source);
+    }
+
+    /**
+     * @test
+     */
+    public function getAssetUrlProperlyResolvesRootPathInAssetUrl(): void
+    {
+        $this->source['url'] = '{cwd}/foo.tar.gz';
+
+        $expected = FilesystemHelper::getWorkingDirectory().'/foo.tar.gz';
+
+        self::assertSame($expected, $this->subject->getAssetUrl($this->source));
+    }
+
+    /**
+     * @test
+     */
+    public function getAssetUrlProperlyResolvesTemporaryFilenameInAssetUrl(): void
+    {
+        $expected = realpath(sys_get_temp_dir());
+
+        self::assertIsString($expected);
+        self::assertStringStartsWith($expected, $this->subject->getAssetUrl($this->source));
+    }
+
+    /**
+     * @test
+     */
+    public function getAssetUrlCanHandleRelativePaths(): void
+    {
+        $this->source['url'] = 'foo.tar.gz';
+
+        $expected = FilesystemHelper::getWorkingDirectory().'/foo.tar.gz';
+
+        self::assertSame($expected, $this->subject->getAssetUrl($this->source));
+    }
+
+    private static function assertArchiveHasChild(string $path, string $archive): void
+    {
+        self::assertFileExists($archive, sprintf('Archive "%s" does not exist.', $archive));
+        self::assertFileExists(
+            'phar://'.$archive.'/'.$path,
+            sprintf('Path "%s" does not exist in archive "%s".', $path, $archive)
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a new provider `local`. It can be used to define a local file as Frontend asset source file.

Example configuration:

```json
{
    "frontend-assets": [
        {
            "source": {
                "type": "local",
                "command": "tar -czvf '{url}' -C '{cwd}/frontend' 'dist'",
                "url": "{temp}.tar.gz"
            },
            "target": {
                "type": "archive",
                "path": "public/assets",
                "base": "dist/"
            }
        }
    ]
}
```

Resolves: #82