### PR TITLE
[!!!][FEATURE] Add temporary file creation method to FilesystemHelper

### DIFF
--- a/src/Helper/FilesystemHelper.php
+++ b/src/Helper/FilesystemHelper.php
@@ -31,6 +31,8 @@ use Phar;
 use Symfony\Component\Filesystem;
 
 use function getcwd;
+use function ltrim;
+use function register_shutdown_function;
 
 /**
  * FilesystemHelper.
@@ -42,6 +44,13 @@ use function getcwd;
  */
 final class FilesystemHelper
 {
+    private static ?Filesystem\Filesystem $filesystem = null;
+
+    /**
+     * @var list<string>
+     */
+    private static array $tempFiles = [];
+
     public static function getProjectDirectory(): string
     {
         $projectDirectory = null;
@@ -63,7 +72,7 @@ final class FilesystemHelper
 
     public static function resolveRelativePath(string $relativePath): string
     {
-        $filesystem = new Filesystem\Filesystem();
+        $filesystem = self::getFilesystem();
 
         if ($filesystem->isAbsolutePath($relativePath)) {
             return $relativePath;
@@ -93,5 +102,38 @@ final class FilesystemHelper
         $encoded = file_get_contents($filePath) ?: '';
 
         return Normalizer\Json::fromEncoded($encoded);
+    }
+
+    public static function createTemporaryFile(string $extension = '', bool $filenameOnly = false): string
+    {
+        $filesystem = self::getFilesystem();
+
+        // Remove all temporary files on shutdown
+        if ([] === self::$tempFiles) {
+            register_shutdown_function(fn () => $filesystem->remove(self::$tempFiles));
+        }
+
+        // Create temporary file
+        $extension = ltrim($extension, '.');
+        $tempFile = $filesystem->tempnam(sys_get_temp_dir(), 'frontend_asset_handler_', $extension ? '.'.$extension : '');
+
+        if ($filenameOnly) {
+            // Remove file if only filename should be returned
+            $filesystem->remove($tempFile);
+        } else {
+            // Register temporary file to be removed on shutdown
+            self::$tempFiles[] = $tempFile;
+        }
+
+        return $tempFile;
+    }
+
+    private static function getFilesystem(): Filesystem\Filesystem
+    {
+        if (null === self::$filesystem) {
+            self::$filesystem = new Filesystem\Filesystem();
+        }
+
+        return self::$filesystem;
     }
 }

--- a/tests/Unit/Helper/FilesystemHelperTest.php
+++ b/tests/Unit/Helper/FilesystemHelperTest.php
@@ -26,10 +26,12 @@ namespace CPSIT\FrontendAssetHandler\Tests\Unit\Helper;
 use CPSIT\FrontendAssetHandler\Exception;
 use CPSIT\FrontendAssetHandler\Helper;
 use Ergebnis\Json\Normalizer;
+use Generator;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function dirname;
+use function pathinfo;
 
 /**
  * FilesystemHelperTest.
@@ -108,5 +110,38 @@ final class FilesystemHelperTest extends TestCase
         self::assertInstanceOf(Normalizer\Json::class, $actual);
         self::assertEquals($expected, $actual->decoded());
         self::assertJsonStringEqualsJsonString('{"foo":"baz"}', $actual->encoded());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider createTemporaryFileCreatesTemporaryFileDataProvider
+     */
+    public function createTemporaryFileCreatesTemporaryFile(string $extension, string $expected): void
+    {
+        $actual = Helper\FilesystemHelper::createTemporaryFile($extension);
+
+        self::assertFileExists($actual);
+        self::assertSame($expected, pathinfo($actual, PATHINFO_EXTENSION));
+    }
+
+    /**
+     * @test
+     */
+    public function createTemporaryFileReturnsOnlyFilename(): void
+    {
+        $actual = Helper\FilesystemHelper::createTemporaryFile(filenameOnly: true);
+
+        self::assertFileDoesNotExist($actual);
+    }
+
+    /**
+     * @return Generator<string, array{string, string}>
+     */
+    public function createTemporaryFileCreatesTemporaryFileDataProvider(): Generator
+    {
+        yield 'no extension' => ['', ''];
+        yield 'extension without dot' => ['foo', 'foo'];
+        yield 'extension with dot' => ['.foo', 'foo'];
     }
 }


### PR DESCRIPTION
The public API of `FilesystemHelper` is now extended by a new method `createTemporaryFile`. It may be used to create files only relevant during script execution. All temporary files will be removed on script shutdown.

This is a breaking change as the handling of temporary files within `HttpFileProvider` is now extracted to the new API method within `FilesystemHelper`, leading to a function signature change in the class constructor.