### PR TITLE
[FEATURE] Introduce `FilesystemHelper::getWorkingDirectory()` method

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -26,12 +26,11 @@ namespace CPSIT\FrontendAssetHandler\Console;
 use Composer\InstalledVersions;
 use CPSIT\FrontendAssetHandler\Command;
 use CPSIT\FrontendAssetHandler\DependencyInjection;
+use CPSIT\FrontendAssetHandler\Helper\FilesystemHelper;
 use OutOfBoundsException;
 use Symfony\Component\Console;
 use Symfony\Component\DependencyInjection as SymfonyDI;
-use Symfony\Component\Filesystem;
 
-use function getcwd;
 use function in_array;
 
 /**
@@ -71,7 +70,7 @@ final class Application extends Console\Application
                 'c',
                 Console\Input\InputOption::VALUE_REQUIRED,
                 'Path to the assets configuration file',
-                Filesystem\Path::join(getcwd() ?: '', 'assets.json'),
+                FilesystemHelper::resolveRelativePath('assets.json'),
             ),
         );
 

--- a/src/Helper/FilesystemHelper.php
+++ b/src/Helper/FilesystemHelper.php
@@ -70,6 +70,23 @@ final class FilesystemHelper
         return Filesystem\Path::canonicalize($projectDirectory);
     }
 
+    public static function getWorkingDirectory(): string
+    {
+        if (Phar::running()) {
+            $cwd = getcwd();
+        } else {
+            $cwd = InstalledVersions::getRootPackage()['install_path'];
+        }
+
+        // @codeCoverageIgnoreStart
+        if (false === $cwd) {
+            throw Exception\FilesystemFailureException::forUnresolvableWorkingDirectory();
+        }
+        // @codeCoverageIgnoreEnd
+
+        return Filesystem\Path::canonicalize($cwd);
+    }
+
     public static function resolveRelativePath(string $relativePath): string
     {
         $filesystem = self::getFilesystem();
@@ -78,19 +95,7 @@ final class FilesystemHelper
             return $relativePath;
         }
 
-        if (Phar::running()) {
-            $basePath = getcwd();
-        } else {
-            $basePath = InstalledVersions::getRootPackage()['install_path'];
-        }
-
-        // @codeCoverageIgnoreStart
-        if (false === $basePath) {
-            throw Exception\FilesystemFailureException::forUnresolvableWorkingDirectory();
-        }
-        // @codeCoverageIgnoreEnd
-
-        return Filesystem\Path::join($basePath, $relativePath);
+        return Filesystem\Path::join(self::getWorkingDirectory(), $relativePath);
     }
 
     public static function parseJsonFileContents(string $filePath): Normalizer\Json

--- a/tests/Unit/Helper/FilesystemHelperTest.php
+++ b/tests/Unit/Helper/FilesystemHelperTest.php
@@ -54,6 +54,16 @@ final class FilesystemHelperTest extends TestCase
     /**
      * @test
      */
+    public function getWorkingDirectoryReturnsCurrentWorkingDirectory(): void
+    {
+        $expected = dirname(__DIR__, 3);
+
+        self::assertSame($expected, Helper\FilesystemHelper::getWorkingDirectory());
+    }
+
+    /**
+     * @test
+     */
     public function resolveRelativePathReturnsGivenPathIfItIsAnAbsolutePath(): void
     {
         $path = '/foo/baz';


### PR DESCRIPTION
This PR adds a new method `getWorkingDirectory()` to the public API of `FilesystemHelper`. It resolves to the path containing the project's root `composer.json` or – when executed as PHAR file – the current working directory.