### PR TITLE
[BUGFIX] Assure source file extension is properly maintained

### DIFF
--- a/src/Provider/HttpFileProvider.php
+++ b/src/Provider/HttpFileProvider.php
@@ -70,7 +70,7 @@ final class HttpFileProvider implements ProviderInterface, ChattyInterface
 
         // Process download
         $url = $this->getAssetUrl($source);
-        $temporaryFile = Helper\FilesystemHelper::createTemporaryFile(pathinfo($url, PATHINFO_EXTENSION));
+        $temporaryFile = Helper\FilesystemHelper::createTemporaryFile(pathinfo($url, PATHINFO_BASENAME));
         $this->processDownload($url, $temporaryFile);
 
         // Verify downloaded file

--- a/tests/Unit/Provider/HttpFileProviderTest.php
+++ b/tests/Unit/Provider/HttpFileProviderTest.php
@@ -221,6 +221,7 @@ final class HttpFileProviderTest extends ContainerAwareTestCase
 
         self::assertInstanceOf(TemporaryAsset::class, $actual);
         self::assertFileExists($actual->getTempFile());
+        self::assertStringEndsWith('.tar.gz', $actual->getTempFile());
     }
 
     /**


### PR DESCRIPTION
This PR fixes a regression introduced with #106 where source file extensions are not properly maintained, e.g. if the file extension is `.tar.gz`.

Resolves: #129