### PR TITLE
[TASK] Unescape slashes when JSON-encoding asset definition

### DIFF
--- a/src/Asset/Definition/AssetDefinition.php
+++ b/src/Asset/Definition/AssetDefinition.php
@@ -108,7 +108,7 @@ abstract class AssetDefinition implements ArrayAccess, IteratorAggregate, JsonSe
 
     public function __toString(): string
     {
-        return json_encode($this, JSON_THROW_ON_ERROR);
+        return json_encode($this, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     }
 
     /**


### PR DESCRIPTION
Asset definitions are JSON-encoded when requesting their string representation, e.g. in various exception classes. Since they should represent its original configuration as much as possible, slashes must not be escaped.