### PR TITLE
[BUGFIX] Improve stability of `init` command in non-interactive mode

### DIFF
--- a/src/Command/InitConfigCommand.php
+++ b/src/Command/InitConfigCommand.php
@@ -75,11 +75,13 @@ final class InitConfigCommand extends Console\Command\Command
      */
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
-        $output->writeln([
-            'Welcome to the Frontend Asset Handler!',
-            'You can use the following command to initialize a new asset configuration for your Frontend assets.',
-            'Follow the guide and answer all relevant questions to get started.',
-        ]);
+        if ($input->isInteractive()) {
+            $output->writeln([
+                'Welcome to the Frontend Asset Handler!',
+                'You can use the following command to initialize a new asset configuration for your Frontend assets.',
+                'Follow the guide and answer all relevant questions to get started.',
+            ]);
+        }
 
         $request = Config\Initialization\InitializationRequest::fromCommandInput($input);
 
@@ -104,7 +106,10 @@ final class InitConfigCommand extends Console\Command\Command
             throw Exception\FilesystemFailureException::forFailedWriteOperation($request->getConfigFile());
         }
 
-        $this->io->newLine();
+        if ($input->isInteractive()) {
+            $this->io->newLine();
+        }
+
         $this->io->success(
             sprintf('Asset configuration was successfully written to %s', $request->getConfigFile()),
         );

--- a/src/Config/Initialization/Step/HandlerConfigStep.php
+++ b/src/Config/Initialization/Step/HandlerConfigStep.php
@@ -62,7 +62,9 @@ final class HandlerConfigStep extends BaseStep implements InteractiveStepInterfa
         $input = $this->getInput($request);
         $io = new Console\Style\SymfonyStyle($input, $this->output);
 
-        $io->title('Handler');
+        if ($input->isInteractive()) {
+            $io->title('Handler');
+        }
 
         // Ask for handler type
         $handlerType = $this->questionHelper->ask(

--- a/src/Config/Initialization/Step/SourceConfigStep.php
+++ b/src/Config/Initialization/Step/SourceConfigStep.php
@@ -91,7 +91,9 @@ final class SourceConfigStep extends BaseStep implements InteractiveStepInterfac
         $input = $this->getInput($request);
         $io = new Console\Style\SymfonyStyle($input, $this->output);
 
-        $io->title('Source');
+        if ($input->isInteractive()) {
+            $io->title('Source');
+        }
 
         // Initialize additional variables
         $additionalVariables = [];

--- a/src/Config/Initialization/Step/TargetConfigStep.php
+++ b/src/Config/Initialization/Step/TargetConfigStep.php
@@ -86,7 +86,9 @@ final class TargetConfigStep extends BaseStep implements InteractiveStepInterfac
         $input = $this->getInput($request);
         $io = new Console\Style\SymfonyStyle($input, $this->output);
 
-        $io->title('Target');
+        if ($input->isInteractive()) {
+            $io->title('Target');
+        }
 
         // Initialize additional variables
         $additionalVariables = [];

--- a/src/Config/Initialization/Step/VcsConfigStep.php
+++ b/src/Config/Initialization/Step/VcsConfigStep.php
@@ -71,7 +71,9 @@ final class VcsConfigStep extends BaseStep implements InteractiveStepInterface
         $input = $this->getInput($request);
         $io = new Console\Style\SymfonyStyle($input, $this->output);
 
-        $io->title('VCS');
+        if ($input->isInteractive()) {
+            $io->title('VCS');
+        }
 
         // Early return if VCS should not be configured
         if (!$this->shouldConfigureVcs($request)) {
@@ -191,10 +193,16 @@ final class VcsConfigStep extends BaseStep implements InteractiveStepInterface
     {
         $config = $request->getConfig();
         $definitionId = (int) $request->getOption('definition-id');
+        $vcsType = $request->getOption('vcs-type');
+
+        // Early return if VCS type is invalid
+        if (!is_string($vcsType)) {
+            return;
+        }
 
         // Define default VCS configuration
         $vcsConfig = [
-            'type' => $request->getOption('vcs-type'),
+            'type' => $vcsType,
         ];
 
         // Merge additional VCS configuration
@@ -213,7 +221,9 @@ final class VcsConfigStep extends BaseStep implements InteractiveStepInterface
             return true;
         }
 
-        $this->output->writeln('The following VCS configuration is optional.');
+        if ($this->getInput($request)->isInteractive()) {
+            $this->output->writeln('The following VCS configuration is optional.');
+        }
 
         return $this->askBooleanQuestion($request, 'Add VCS configuration?');
     }


### PR DESCRIPTION
This PR improves user-oriented output of the `init` command when running in non-interactive mode. In addition, it fixes a bug where omitting the optional VCS type led to a validation error in non-interactive mode.