### PR TITLE
[!!!][TASK] Move `gmostafa/php-graphql-client` to package suggestions

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -26,15 +26,19 @@ jobs:
 
       # Validation
       - name: Validate composer.json
-        run: composer validate --no-check-lock
+        run: composer validate
 
       # Install dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        run: composer require --no-progress gmostafa/php-graphql-client:"^1.3"
 
       # Check Composer dependencies
       - name: Check dependencies
         run: composer-require-checker check
+      - name: Reset composer.json
+        run: git checkout composer.json composer.lock
+      - name: Re-install Composer dependencies
+        uses: ramsey/composer-install@v2
       - name: Check for unused dependencies
         run: composer-unused --excludePackage=symfony/finder --excludePackage=symfony/yaml
 

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -30,7 +30,7 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        run: composer require --no-progress gmostafa/php-graphql-client:"^1.3"
+        run: composer require --no-progress gmostafa/php-graphql-client:"^1.13"
 
       # Check Composer dependencies
       - name: Check dependencies

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
 			"@lint:php:fix"
 		],
 		"lint:composer": "@lint:composer:fix --dry-run",
-		"lint:composer:fix": "@composer normalize --no-check-lock --no-update-lock",
+		"lint:composer:fix": "@composer normalize",
 		"lint:editorconfig": "ec",
 		"lint:editorconfig:fix": "@lint:editorconfig --fix",
 		"lint:php": "@lint:php:fix --dry-run",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
 		"ergebnis/json-normalizer": ">= 1.0 < 3.0",
 		"ergebnis/json-printer": "^3.0",
 		"ergebnis/json-schema-validator": "^2.0",
-		"gmostafa/php-graphql-client": "^1.13",
 		"guzzlehttp/guzzle": "^7.0",
 		"guzzlehttp/psr7": ">= 1.8 < 3.0",
 		"justinrainbow/json-schema": "^5.2",
@@ -40,6 +39,7 @@
 		"armin/editorconfig-cli": "^1.5",
 		"ergebnis/composer-normalize": "^2.18",
 		"friendsofphp/php-cs-fixer": "^3.0",
+		"gmostafa/php-graphql-client": "^1.13",
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan": "^1.2",
 		"phpstan/phpstan-deprecation-rules": "^1.1",
@@ -48,6 +48,9 @@
 		"phpstan/phpstan-webmozart-assert": "^1.2",
 		"phpunit/phpunit": "^10.1",
 		"rector/rector": "^0.15.0 || ^0.16.0 || ^0.17.0"
+	},
+	"suggest": {
+		"gmostafa/php-graphql-client": "Used to perform GraphQL requests within GithubVcsProvider (^1.13)"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1ce5f068f269e575fd51a33c301ea64",
+    "content-hash": "d36c2a642e609aaabe2433496e065598",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",
@@ -198,71 +198,6 @@
                 }
             ],
             "time": "2021-12-13T16:54:56+00:00"
-        },
-        {
-            "name": "gmostafa/php-graphql-client",
-            "version": "v1.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mghoneimy/php-graphql-client.git",
-                "reference": "caadeba3e8af0d3d5cf6481e393cf933f3a83f3c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mghoneimy/php-graphql-client/zipball/caadeba3e8af0d3d5cf6481e393cf933f3a83f3c",
-                "reference": "caadeba3e8af0d3d5cf6481e393cf933f3a83f3c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "guzzlehttp/guzzle": "^6.3|^7.0.1",
-                "php": "^7.1 || ^8.0",
-                "psr/http-client": "^1.0",
-                "psr/http-message": "^1.0"
-            },
-            "conflict": {
-                "guzzlehttp/psr7": "< 1.7.0"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "^3.186",
-                "codacy/coverage": "^1.4",
-                "phpunit/phpunit": "^7.5|^8.0|^9.0"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "Move this package to require section to use AWS IAM authorization",
-                "gmostafa/php-graphql-oqm": "To have object-to-query mapping support"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "GraphQL\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mostafa Ghoneimy",
-                    "email": "emostafagh@gmail.com"
-                }
-            ],
-            "description": "GraphQL client and query builder.",
-            "keywords": [
-                "builder",
-                "client",
-                "graph-ql",
-                "graphql",
-                "php",
-                "query",
-                "query-builder"
-            ],
-            "support": {
-                "issues": "https://github.com/mghoneimy/php-graphql-client/issues",
-                "source": "https://github.com/mghoneimy/php-graphql-client/tree/v1.13"
-            },
-            "time": "2021-08-10T12:39:57+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2797,6 +2732,71 @@
                 }
             ],
             "time": "2023-06-27T20:22:39+00:00"
+        },
+        {
+            "name": "gmostafa/php-graphql-client",
+            "version": "v1.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mghoneimy/php-graphql-client.git",
+                "reference": "caadeba3e8af0d3d5cf6481e393cf933f3a83f3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mghoneimy/php-graphql-client/zipball/caadeba3e8af0d3d5cf6481e393cf933f3a83f3c",
+                "reference": "caadeba3e8af0d3d5cf6481e393cf933f3a83f3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.3|^7.0.1",
+                "php": "^7.1 || ^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "conflict": {
+                "guzzlehttp/psr7": "< 1.7.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.186",
+                "codacy/coverage": "^1.4",
+                "phpunit/phpunit": "^7.5|^8.0|^9.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Move this package to require section to use AWS IAM authorization",
+                "gmostafa/php-graphql-oqm": "To have object-to-query mapping support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mostafa Ghoneimy",
+                    "email": "emostafagh@gmail.com"
+                }
+            ],
+            "description": "GraphQL client and query builder.",
+            "keywords": [
+                "builder",
+                "client",
+                "graph-ql",
+                "graphql",
+                "php",
+                "query",
+                "query-builder"
+            ],
+            "support": {
+                "issues": "https://github.com/mghoneimy/php-graphql-client/issues",
+                "source": "https://github.com/mghoneimy/php-graphql-client/tree/v1.13"
+            },
+            "time": "2021-08-10T12:39:57+00:00"
         },
         {
             "name": "idiosyncratic/editorconfig",

--- a/src/Exception/MissingPackageException.php
+++ b/src/Exception/MissingPackageException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Composer package "cpsit/frontend-asset-handler".
  *
- * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,21 +25,24 @@ namespace CPSIT\FrontendAssetHandler\Exception;
 
 use Exception;
 
+use function sprintf;
+
 /**
- * MissingConfigurationException.
+ * MissingPackageException.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class MissingConfigurationException extends Exception
+final class MissingPackageException extends Exception
 {
-    public static function create(): self
+    /**
+     * @param non-empty-string $packageName
+     */
+    public static function create(string $packageName): self
     {
-        return new self('The asset configuration is missing.', 1661844293);
-    }
-
-    public static function forKey(string $key): self
-    {
-        return new self(sprintf('Configuration for key "%s" is missing or invalid.', $key), 1623867663);
+        return new self(
+            sprintf('The package "%1$s" is not installed. Please run "composer require %1$s".', $packageName),
+            1687631353,
+        );
     }
 }

--- a/src/Vcs/GithubVcsProvider.php
+++ b/src/Vcs/GithubVcsProvider.php
@@ -35,6 +35,7 @@ use GraphQL\Util;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7;
 
+use function class_exists;
 use function explode;
 use function in_array;
 use function is_array;
@@ -240,15 +241,26 @@ final class GithubVcsProvider implements DeployableVcsProviderInterface
         return $data;
     }
 
+    /**
+     * @throws Exception\MissingPackageException
+     */
     private function getClient(): Client
     {
-        if (null === $this->graphQlClient) {
-            $this->graphQlClient = new Client(
-                self::API_URL,
-                ['Authorization' => 'Bearer '.$this->accessToken],
-                httpClient: new Util\GuzzleAdapter($this->client),
-            );
+        if (null !== $this->graphQlClient) {
+            return $this->graphQlClient;
         }
+
+        // @codeCoverageIgnoreStart
+        if (!class_exists(Client::class)) {
+            throw Exception\MissingPackageException::create('gmostafa/php-graphql-client');
+        }
+        // @codeCoverageIgnoreEnd
+
+        $this->graphQlClient = new Client(
+            self::API_URL,
+            ['Authorization' => 'Bearer '.$this->accessToken],
+            httpClient: new Util\GuzzleAdapter($this->client),
+        );
 
         return $this->graphQlClient;
     }

--- a/tests/Unit/Exception/MissingPackageExceptionTest.php
+++ b/tests/Unit/Exception/MissingPackageExceptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Composer package "cpsit/frontend-asset-handler".
  *
- * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,25 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\FrontendAssetHandler\Exception;
+namespace CPSIT\FrontendAssetHandler\Tests\Unit\Exception;
 
-use Exception;
+use CPSIT\FrontendAssetHandler\Exception\MissingPackageException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 
 /**
- * MissingConfigurationException.
+ * MissingPackageExceptionTest.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class MissingConfigurationException extends Exception
+final class MissingPackageExceptionTest extends TestCase
 {
-    public static function create(): self
+    #[Test]
+    public function createReturnsExceptionForMissingPackage(): void
     {
-        return new self('The asset configuration is missing.', 1661844293);
-    }
+        $subject = MissingPackageException::create('foo');
 
-    public static function forKey(string $key): self
-    {
-        return new self(sprintf('Configuration for key "%s" is missing or invalid.', $key), 1623867663);
+        self::assertSame('The package "foo" is not installed. Please run "composer require foo".', $subject->getMessage());
+        self::assertSame(1687631353, $subject->getCode());
     }
 }


### PR DESCRIPTION
The `gmostafa/php-graphql-client` package is not required in most cases, because it's only used within the VCS provider `github`. Since VCS providers are optional and most probably `gitlab` is used, we no longer require end-users to install this package. Instead, it is now suggested during `composer install` and `composer update` for the outlined case.

Resolves: #207