### PR TITLE
[TASK] Streamline `lint` and `fix` CGL scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,14 @@ composer lint
 composer lint:composer
 composer lint:editorconfig
 composer lint:php
+
+# Fix all CGL issues
+composer fix
+
+# Fix specific CGL issues
+composer fix:composer
+composer fix:editorconfig
+composer fix:php
 ```
 
 ## Run static code analysis

--- a/composer.json
+++ b/composer.json
@@ -74,17 +74,22 @@
 		"sort-packages": true
 	},
 	"scripts": {
-		"lint": [
-			"@lint:composer:fix",
-			"@lint:editorconfig:fix",
-			"@lint:php:fix"
+		"fix": [
+			"@fix:composer",
+			"@fix:editorconfig",
+			"@fix:php"
 		],
-		"lint:composer": "@lint:composer:fix --dry-run",
-		"lint:composer:fix": "@composer normalize",
+		"fix:composer": "@composer normalize",
+		"fix:editorconfig": "@lint:editorconfig --fix",
+		"fix:php": "php-cs-fixer fix",
+		"lint": [
+			"@lint:composer",
+			"@lint:editorconfig",
+			"@lint:php"
+		],
+		"lint:composer": "@fix:composer --dry-run",
 		"lint:editorconfig": "ec",
-		"lint:editorconfig:fix": "@lint:editorconfig --fix",
-		"lint:php": "@lint:php:fix --dry-run",
-		"lint:php:fix": "php-cs-fixer fix",
+		"lint:php": "@fix:php --dry-run",
 		"migration": [
 			"@migration:rector"
 		],


### PR DESCRIPTION
This PR harmonizes the usage of CGL scripts:

- `lint` scripts no longer fix CGL issues, but only print them to the console (dry-run mode)
- `fix` scripts actually fix CGL issues (like done before with `lint:<program>:fix`)