### PR TITLE
[TASK] Use Renovate config presets from CPS config repository

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,31 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"config:base",
-		"schedule:weekdays",
-		":automergeRequireAllStatusChecks"
-	],
-	"baseBranches": [
-		"develop"
-	],
-	"commitMessagePrefix": "[TASK] ",
-	"commitMessageTopic": "{{depName}}",
-	"labels": [
-		"dependencies"
-	],
-	"lockFileMaintenance": {
-		"enabled": true,
-		"commitMessageAction": "Update composer.lock"
-	},
-	"packageRules": [
-		{
-			"matchUpdateTypes": [
-				"minor",
-				"patch"
-			],
-			"automerge": true
-		}
-	],
-	"platformAutomerge": true,
-	"prConcurrentLimit": 10
+		"local>CPS-IT/renovate-config",
+		"local>CPS-IT/renovate-config:git-flow"
+	]
 }


### PR DESCRIPTION
This PR modifies the `renovate.json` file to use shared config presets from `CPS-IT/renovate-config` repository.