### PR TITLE
[BUGFIX] Correctly determine file extension of gzipped files

### DIFF
--- a/src/Helper/FilesystemHelper.php
+++ b/src/Helper/FilesystemHelper.php
@@ -32,7 +32,11 @@ use Symfony\Component\Filesystem;
 
 use function getcwd;
 use function ltrim;
+use function pathinfo;
 use function register_shutdown_function;
+use function str_ends_with;
+use function strtolower;
+use function substr;
 
 /**
  * FilesystemHelper.
@@ -131,6 +135,17 @@ final class FilesystemHelper
         }
 
         return $tempFile;
+    }
+
+    public static function getFileExtension(string $path): string
+    {
+        $normalizedPath = strtolower($path);
+
+        if (str_ends_with($normalizedPath, '.gz')) {
+            return pathinfo(substr($normalizedPath, 0, -3), PATHINFO_EXTENSION).'.gz';
+        }
+
+        return pathinfo($normalizedPath, PATHINFO_EXTENSION);
     }
 
     private static function getFilesystem(): Filesystem\Filesystem

--- a/src/Provider/HttpFileProvider.php
+++ b/src/Provider/HttpFileProvider.php
@@ -70,7 +70,7 @@ final class HttpFileProvider implements ProviderInterface, ChattyInterface
 
         // Process download
         $url = $this->getAssetUrl($source);
-        $temporaryFile = Helper\FilesystemHelper::createTemporaryFile(pathinfo($url, PATHINFO_BASENAME));
+        $temporaryFile = Helper\FilesystemHelper::createTemporaryFile(Helper\FilesystemHelper::getFileExtension($url));
         $this->processDownload($url, $temporaryFile);
 
         // Verify downloaded file

--- a/tests/Unit/Helper/FilesystemHelperTest.php
+++ b/tests/Unit/Helper/FilesystemHelperTest.php
@@ -127,6 +127,13 @@ final class FilesystemHelperTest extends TestCase
         self::assertFileDoesNotExist($actual);
     }
 
+    #[Test]
+    #[DataProvider('getFileExtensionReturnsFileExtensionDataProvider')]
+    public function getFileExtensionReturnsFileExtension(string $path, string $expected): void
+    {
+        self::assertSame($expected, Helper\FilesystemHelper::getFileExtension($path));
+    }
+
     /**
      * @return Generator<string, array{string, string}>
      */
@@ -135,5 +142,15 @@ final class FilesystemHelperTest extends TestCase
         yield 'no extension' => ['', ''];
         yield 'extension without dot' => ['foo', 'foo'];
         yield 'extension with dot' => ['.foo', 'foo'];
+    }
+
+    /**
+     * @return Generator<string, array{string, string}>
+     */
+    public static function getFileExtensionReturnsFileExtensionDataProvider(): Generator
+    {
+        yield 'no extension' => ['/tmp/foo', ''];
+        yield 'simple extension' => ['/tmp/foo.bar', 'bar'];
+        yield 'gzipped extension' => ['/tmp/foo.bar.gz', 'bar.gz'];
     }
 }


### PR DESCRIPTION
It turns out, there are still problems with detecting the correct file extension of gzipped files. In order to stabilize file extension determination, a new helper method `FilesystemHelper::getFileExtension()` is introduced. It supports normal files and gzipped files.