### PR TITLE
[TASK] Drop Git Flow and use main branch as default branch

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -3,10 +3,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
-      - '**'
+      - main
 
 jobs:
   cgl:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,10 +3,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
-      - '**'
+      - main
 
 jobs:
   tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,12 +75,8 @@ Once you have finished your work, please **submit a pull request** and describe
 what you've done. Ideally, your PR references an issue describing the problem
 you're trying to solve.
 
-**Note: As we're using [Git Flow][1], please make sure to submit your pull request
-against the `develop` branch of this repository.**
-
 All described code quality tools are automatically executed on each pull request
 for all currently supported PHP versions. Take a look at the appropriate
-[workflows][2] to get a detailed overview.
+[workflows][1] to get a detailed overview.
 
-[1]: http://nvie.com/git-model
-[2]: .github/workflows
+[1]: .github/workflows

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Frontend Asset Handler
 
-[![Coverage](https://codecov.io/gh/CPS-IT/frontend-asset-handler/branch/develop/graph/badge.svg?token=P4F5YYWAJX)](https://codecov.io/gh/CPS-IT/frontend-asset-handler)
+[![Coverage](https://codecov.io/gh/CPS-IT/frontend-asset-handler/branch/main/graph/badge.svg?token=P4F5YYWAJX)](https://codecov.io/gh/CPS-IT/frontend-asset-handler)
 [![Tests](https://github.com/CPS-IT/frontend-asset-handler/actions/workflows/tests.yaml/badge.svg)](https://github.com/CPS-IT/frontend-asset-handler/actions/workflows/tests.yaml)
 [![CGL](https://github.com/CPS-IT/frontend-asset-handler/actions/workflows/cgl.yaml/badge.svg)](https://github.com/CPS-IT/frontend-asset-handler/actions/workflows/cgl.yaml)
 [![Latest Stable Version](http://poser.pugx.org/cpsit/frontend-asset-handler/v)](https://packagist.org/packages/cpsit/frontend-asset-handler)

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"local>CPS-IT/renovate-config",
-		"local>CPS-IT/renovate-config:git-flow"
+		"local>CPS-IT/renovate-config"
 	],
 	"assignees": [
 		"eliashaeussler"


### PR DESCRIPTION
This PR drops usage of Git Flow and therefore drops usage of `develop` as default development branch. Instead, `main` is now used instead.