### PR TITLE
[TASK] Add `services` to schema and simplify parsing

### DIFF
--- a/resources/configuration.schema.json
+++ b/resources/configuration.schema.json
@@ -15,6 +15,11 @@
 			"items": {
 				"$ref": "#/definitions/asset-definition"
 			}
+		},
+		"services": {
+			"type": "array",
+			"title": "Service configurations",
+			"description": "A list of additional service configurations, can be relative to the current working directory."
 		}
 	},
 	"definitions": {

--- a/src/Config/Parser/ServicesParser.php
+++ b/src/Config/Parser/ServicesParser.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Config\Parser;
 
-use Closure;
 use CPSIT\FrontendAssetHandler\Config;
 use CPSIT\FrontendAssetHandler\Exception;
 use CPSIT\FrontendAssetHandler\Helper;
@@ -43,21 +42,24 @@ use function is_callable;
  */
 final class ServicesParser
 {
-    public function parse(Config\Config $config): Config\Config
+    /**
+     * @return list<string>
+     */
+    public function parse(Config\Config $config): array
     {
-        $newConfig = new Config\Config(['services' => []], $config->getFilePath());
+        $services = [];
 
         if ([] === ($config['services'] ?? [])) {
-            return $newConfig;
+            return [];
         }
 
         foreach ($config['services'] as $service) {
             $filePath = Helper\FilesystemHelper::resolveRelativePath($service);
             $this->validateService($filePath);
-            $newConfig['services'][] = $filePath;
+            $services[] = $filePath;
         }
 
-        return $newConfig;
+        return $services;
     }
 
     private function validateService(string $filePath): void
@@ -84,7 +86,7 @@ final class ServicesParser
             throw Exception\UnprocessableConfigFileException::create($filePath);
         }
 
-        $reflection = new ReflectionFunction(Closure::fromCallable($callable));
+        $reflection = new ReflectionFunction($callable(...));
         $parameters = $reflection->getParameters();
 
         if ([] === $parameters) {

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -90,7 +90,7 @@ final class ContainerFactory
         // Include external service configuration (skipped when creating failsafe container)
         if (null !== $this->configFile) {
             $config = $this->configLoader->load($this->configFile);
-            $services = $this->servicesParser->parse($config)['services'];
+            $services = $this->servicesParser->parse($config);
             $configFiles = array_merge($configFiles, $services);
         }
 

--- a/tests/Unit/Config/Parser/ServicesParserTest.php
+++ b/tests/Unit/Config/Parser/ServicesParserTest.php
@@ -51,9 +51,8 @@ final class ServicesParserTest extends TestCase
     public function parseDoesNothingIfNoServicesAreConfiguredInGivenConfig(): void
     {
         $config = new Config\Config([], 'foo');
-        $expected = new Config\Config(['services' => []], 'foo');
 
-        self::assertEquals($expected, $this->subject->parse($config));
+        self::assertEquals([], $this->subject->parse($config));
     }
 
     #[Test]
@@ -105,7 +104,7 @@ final class ServicesParserTest extends TestCase
     {
         $config = new Config\Config(['services' => [$filePath]], 'foo');
 
-        self::assertEquals($config, $this->subject->parse($config));
+        self::assertEquals([$filePath], $this->subject->parse($config));
     }
 
     /**


### PR DESCRIPTION
This PR adds the already supported `services` object to configuration schema. In addition, parsing of service configuration files is simplified.