### PR TITLE
[BUGFIX] Disallow additional properties on root scope of config files

### DIFF
--- a/resources/configuration.schema.json
+++ b/resources/configuration.schema.json
@@ -22,6 +22,7 @@
 			"description": "A list of additional service configurations, can be relative to the current working directory."
 		}
 	},
+	"additionalProperties": false,
 	"definitions": {
 		"asset-definition": {
 			"type": "object",


### PR DESCRIPTION
This PR updates the configuration schema to only allow the configured `frontend-assets` and `services` properties on root level.