### PR TITLE
[BUGFIX] Add return type hint to doRun method

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -77,7 +77,7 @@ final class Application extends Console\Application
         return $inputDefinition;
     }
 
-    public function doRun(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
+    public function doRun(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
         $this->input = $input;
 


### PR DESCRIPTION
This change adds an integer return type hint to the doRun method in the Application class. This ensures the declaration is compatible with the symfony console input interface.