### PR TITLE
[!!!][FEATURE] Use more generic default for environment map

### DIFF
--- a/docs/config/environments.md
+++ b/docs/config/environments.md
@@ -65,15 +65,11 @@ resolves to the following mapping table:
 
 | Branch                             | Environment                      | Fallback |
 |------------------------------------|----------------------------------|----------|
-| `main`                             | [`{version}`](source.md#version) | `stable` |
-| `master`                           | [`{version}`](source.md#version) | `stable` |
-| `develop`                          | `latest`                         | –        |
-| `release/*`                        | `latest`                         | –        |
-| `feature/*`                        | `fe-{slug}`                      | –        |
-| `preview`                          | `preview`                        | –        |
-| `integration`                      | `integration`                    | –        |
+| `main`                             | [`{version}`](source.md#version) | `{slug}` |
+| `master`                           | [`{version}`](source.md#version) | `{slug}` |
 | `renovate/*`                       | `latest`                         | –        |
 | `/^v?\d+\.\d+\.\d+$/`<sup>1)</sup> | `{branch}`<sup>1)</sup>          | –        |
+| `*` (= everything else)            | `{slug}`                         | –        |
 
 _<sup>1)</sup> If a specific version number is given, then exactly this version number is
 also requested as the asset environment. In this case, no mapping takes place._

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,10 @@
 
 ## 4.x → 5.0.0
 
+* Default environment map has changed.
+  - All branches except `renovate/*` now use or fall back to their slug representation.
+  - See [Configuration](config/environments.md#environment-resolving) for a
+    detailed overview.
 * Minimum PHP version is now 8.2.
   - Upgrade your code base to PHP 8.2.
 

--- a/tests/src/Asset/Definition/AssetDefinitionFactoryTest.php
+++ b/tests/src/Asset/Definition/AssetDefinitionFactoryTest.php
@@ -27,7 +27,6 @@ use CPSIT\FrontendAssetHandler\Asset\Definition\AssetDefinitionFactory;
 use CPSIT\FrontendAssetHandler\Asset\Definition\Source;
 use CPSIT\FrontendAssetHandler\Asset\Definition\Target;
 use CPSIT\FrontendAssetHandler\Asset\Definition\Vcs;
-use CPSIT\FrontendAssetHandler\Asset\Environment\Environment;
 use CPSIT\FrontendAssetHandler\Asset\Environment\Map\MapFactory;
 use CPSIT\FrontendAssetHandler\Tests\ContainerAwareTestCase;
 use CPSIT\FrontendAssetHandler\Vcs\GitlabVcsProvider;
@@ -101,7 +100,7 @@ final class AssetDefinitionFactoryTest extends ContainerAwareTestCase
             return $source;
         };
 
-        yield 'no config' => [[], $buildSource(Environment::Stable->value)];
+        yield 'no config' => [[], $buildSource('main')];
         yield 'custom map' => [
             [
                 'environments' => [
@@ -121,7 +120,7 @@ final class AssetDefinitionFactoryTest extends ContainerAwareTestCase
                     'merge' => true,
                 ],
             ],
-            $buildSource(Environment::Stable->value),
+            $buildSource('main'),
         ];
         yield 'version' => [
             [
@@ -168,7 +167,7 @@ final class AssetDefinitionFactoryTest extends ContainerAwareTestCase
                     'merge' => true,
                 ],
             ],
-            $buildVcs(Environment::Stable->value),
+            $buildVcs('main'),
         ];
         yield 'version' => [
             [

--- a/tests/src/Asset/Environment/EnvironmentResolverTest.php
+++ b/tests/src/Asset/Environment/EnvironmentResolverTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace CPSIT\FrontendAssetHandler\Tests\Asset\Environment;
 
-use CPSIT\FrontendAssetHandler\Asset\Environment\Environment;
 use CPSIT\FrontendAssetHandler\Asset\Environment\EnvironmentResolver;
 use CPSIT\FrontendAssetHandler\Asset\Environment\Map\MapFactory;
 use PHPUnit\Framework\Attributes\Test;
@@ -45,23 +44,18 @@ final class EnvironmentResolverTest extends TestCase
     }
 
     #[Test]
-    public function resolveReturnsDefaultEnvironmentIfGivenBranchDoesNotMatch(): void
-    {
-        self::assertSame(Environment::Stable->value, $this->subject->resolve('foo'));
-    }
-
-    #[Test]
     public function resolveReturnsTransformedEnvironment(): void
     {
-        self::assertSame(Environment::Stable->value, $this->subject->resolve('main'));
-        self::assertSame(Environment::Stable->value, $this->subject->resolve('master'));
-        self::assertSame(Environment::Latest->value, $this->subject->resolve('develop'));
-        self::assertSame(Environment::Latest->value, $this->subject->resolve('release/*'));
-        self::assertSame('fe-feature-foo', $this->subject->resolve('feature/foo'));
+        self::assertSame('main', $this->subject->resolve('main'));
+        self::assertSame('master', $this->subject->resolve('master'));
+        self::assertSame('develop', $this->subject->resolve('develop'));
+        self::assertSame('release-1.0.0', $this->subject->resolve('release/1.0.0'));
+        self::assertSame('feature-foo', $this->subject->resolve('feature/foo'));
         self::assertSame('preview', $this->subject->resolve('preview'));
         self::assertSame('integration', $this->subject->resolve('integration'));
         self::assertSame('1.0.0', $this->subject->resolve('1.0.0'));
-        self::assertSame(Environment::Stable->value, $this->subject->resolve('test/foo.foo.foo'));
+        self::assertSame('test-foo.foo.foo', $this->subject->resolve('test/foo.foo.foo'));
+        self::assertSame('foo', $this->subject->resolve('foo'));
     }
 
     #[Test]

--- a/tests/src/Asset/Environment/Map/MapFactoryTest.php
+++ b/tests/src/Asset/Environment/Map/MapFactoryTest.php
@@ -163,21 +163,18 @@ final class MapFactoryTest extends ContainerAwareTestCase
      */
     public static function createDefaultReturnsDefaultMapDataProvider(): Generator
     {
+        $slugTransformer = new SlugTransformer();
         $latestTransformer = new StaticTransformer(Environment::Latest->value);
         $passthroughTransformer = new PassthroughTransformer();
         $defaultMap = fn (TransformerInterface $stableTransformer): Map => new Map([
             new Pair('main', $stableTransformer),
             new Pair('master', $stableTransformer),
-            new Pair('develop', $latestTransformer),
-            new Pair('release/*', $latestTransformer),
-            new Pair('feature/*', new SlugTransformer('fe-{slug}')),
-            new Pair('preview', $passthroughTransformer),
-            new Pair('integration', $passthroughTransformer),
             new Pair('renovate/*', $latestTransformer),
             new Pair('/^v?\\d+\\.\\d+\\.\\d+$/', $passthroughTransformer),
+            new Pair('*', $slugTransformer),
         ]);
 
-        yield 'no version' => [null, $defaultMap(new StaticTransformer(Environment::Stable->value))];
+        yield 'no version' => [null, $defaultMap($slugTransformer)];
         yield 'with version' => ['1.0.0', $defaultMap(new VersionTransformer('1.0.0'))];
     }
 }


### PR DESCRIPTION
The default environment map has changed. All branches except `renovate/*` now use or fall back to their slug representation.